### PR TITLE
Created new function get_nooa() in response.py

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -97,7 +97,8 @@ class OneLogin_Saml2_Auth(object):
                 self.__attributes = response.get_attributes()
                 self.__nameid = response.get_nameid()
                 self.__session_index = response.get_session_index()
-                self.__session_expiration = response.get_session_not_on_or_after()
+                #self.__session_expiration = response.get_session_not_on_or_after()
+                self.__session_expiration = response.get_nooa()
                 self.__authenticated = True
 
             else:

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -316,6 +316,33 @@ class OneLogin_Saml2_Response(object):
             not_on_or_after = OneLogin_Saml2_Utils.parse_SAML_to_time(authn_statement_nodes[0].get('SessionNotOnOrAfter'))
         return not_on_or_after
 
+    # Created new function logic from is_valid() to return the NotOnOrAfter date.
+    def get_nooa(self):
+        """
+        Gets the SessionNotOnOrAfter from the AuthnStatement
+        Could be used to set the local session expiration
+
+        :returns: The SessionNotOnOrAfter value
+        :rtype: time|None
+        """
+
+        nooa_value = None
+
+        subject_confirmation_nodes = self.__query_assertion('/saml:Subject/saml:SubjectConfirmation')
+        for scn in subject_confirmation_nodes:
+            method = scn.get('Method', None)
+            if method and method != OneLogin_Saml2_Constants.CM_BEARER:
+                continue
+        
+            sc_data = scn.find('saml:SubjectConfirmationData', namespaces=OneLogin_Saml2_Constants.NSMAP)
+            if sc_data is None:
+                continue
+            else:
+                nooa_value = sc_data.get('NotOnOrAfter', None)
+        return nooa_value
+
+
+
     def get_session_index(self):
         """
         Gets the SessionIndex from the AuthnStatement


### PR DESCRIPTION
Used the logic from is_valid() and created a new function called get_nooa(). Then I called this function in auth.py to return the NotOnOrAfter time, which can be used to invalidate session data after a time period. 