### PR TITLE
Fix logout on Python 2

### DIFF
--- a/src/onelogin/saml2/xml_utils.py
+++ b/src/onelogin/saml2/xml_utils.py
@@ -27,9 +27,9 @@ class OneLogin_Saml2_XML(object):
     _unparse_etree = staticmethod(etree.tostring)
 
     dump = staticmethod(etree.dump)
-    make_root = etree.Element
-    make_child = etree.SubElement
-    cleanup_namespaces = etree.cleanup_namespaces
+    make_root = staticmethod(etree.Element)
+    make_child = staticmethod(etree.SubElement)
+    cleanup_namespaces = staticmethod(etree.cleanup_namespaces)
 
     @staticmethod
     def to_string(xml, **kwargs):


### PR DESCRIPTION
This patch makes make_root, make_child and cleanup_namespaces static in order to prevent this error that we had on python2

```
Environment:


Request Method: GET
Request URL: http://localhost:8000/saml/logout/

Django Version: 1.8.3
Python Version: 2.7.10
Installed Applications:
(u'flat',
 u'django.contrib.admin',
 u'django.contrib.auth',
 u'django.contrib.contenttypes',
 u'django.contrib.sessions',
 u'django.contrib.messages',
 u'django.contrib.staticfiles',
 u'django.contrib.sites',
 u'django_extensions')
Installed Middleware:
(u'django.contrib.sessions.middleware.SessionMiddleware',
 u'corsheaders.middleware.CorsMiddleware',
 u'django.middleware.common.CommonMiddleware',
 u'django.middleware.csrf.CsrfViewMiddleware',
 u'django.contrib.auth.middleware.AuthenticationMiddleware',
 u'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 u'django.contrib.messages.middleware.MessageMiddleware',
 u'django.middleware.clickjacking.XFrameOptionsMiddleware',
 u'django.middleware.security.SecurityMiddleware',
 u'django.middleware.locale.LocaleMiddleware')


Traceback:
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, callback_args, *callback_kwargs)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/views/generic/base.py" in view
  71.             return self.dispatch(request, args, *kwargs)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  34.             return bound_func(*args, **kwargs)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  30.                 return func.__get__(self, type(self))(*args2, **kwargs2)
File "/Users/marco/Documents/Projects/PWC-AuditExplorerExplorer/saml_authentication/views.py" in dispatch
  17.         return super(CsrfExemptView, self).dispatch(request, args, *kwargs)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/django/views/generic/base.py" in dispatch
  89.         return handler(request, args, *kwargs)
File "/Users/marco/Documents/Projects/PWC-AuditExplorerExplorer/saml_authentication/views.py" in get
  75.         return HttpResponseRedirect(auth.logout(name_id=name_id, session_index=session_index))
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/onelogin/saml2/auth.py" in logout
  309.         logout_request = OneLogin_Saml2_Logout_Request(self.__settings, name_id=name_id, session_index=session_index)
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/onelogin/saml2/logout_request.py" in init
  73.                 cert
File "/Users/marco/.virtualenvs/pwc-auditexplorer/lib/python2.7/site-packages/onelogin/saml2/utils.py" in generate_name_id
  549.         root = OneLogin_Saml2_XML.make_root("{%s}container" % OneLogin_Saml2_Constants.NS_SAML)

Exception Type: TypeError at /saml/logout/
Exception Value: unbound method cython_function_or_method object must be called with OneLogin_Saml2_XML instance as first argument (got str instance instead)
```