### PR TITLE
Return empty list when there are no audience values

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -243,12 +243,8 @@ class OneLogin_Saml2_Response(object):
         :returns: The valid audiences for the SAML Response
         :rtype: list
         """
-        audiences = []
-
         audience_nodes = self.__query_assertion('/saml:Conditions/saml:AudienceRestriction/saml:Audience')
-        for audience_node in audience_nodes:
-            audiences.append(audience_node.text)
-        return audiences
+        return [node.text for node in audience_nodes if node.text is not None]
 
     def get_issuers(self):
         """


### PR DESCRIPTION
Seems like we should be returning an empty list instead of `[None]` when parsing the below in the SAML Response:

```
<saml:AudienceRestriction>
    <saml:Audience/>
</saml:AudienceRestriction>
```