### PR TITLE
passing NameQualifier through to logout request

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -291,7 +291,7 @@ class OneLogin_Saml2_Auth(object):
             self.add_request_signature(parameters, security['signatureAlgorithm'])
         return self.redirect_to(self.get_sso_url(), parameters)
 
-    def logout(self, return_to=None, name_id=None, session_index=None):
+    def logout(self, return_to=None, name_id=None, session_index=None, nq=None):
         """
         Initiates the SLO process.
 
@@ -303,6 +303,9 @@ class OneLogin_Saml2_Auth(object):
 
         :param session_index: SessionIndex that identifies the session of the user.
         :type session_index: string
+
+        :param nq: IDP Name Qualifier
+        :type: string
 
         :returns: Redirection url
         """
@@ -316,7 +319,12 @@ class OneLogin_Saml2_Auth(object):
         if name_id is None and self.__nameid is not None:
             name_id = self.__nameid
 
-        logout_request = OneLogin_Saml2_Logout_Request(self.__settings, name_id=name_id, session_index=session_index)
+        logout_request = OneLogin_Saml2_Logout_Request(
+            self.__settings,
+            name_id=name_id,
+            session_index=session_index,
+            nq=nq
+        )
 
         parameters = {'SAMLRequest': logout_request.get_request()}
         if return_to is not None:

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -24,7 +24,7 @@ class OneLogin_Saml2_Logout_Request(object):
 
     """
 
-    def __init__(self, settings, request=None, name_id=None, session_index=None):
+    def __init__(self, settings, request=None, name_id=None, session_index=None, nq=None):
         """
         Constructs the Logout Request object.
 
@@ -39,6 +39,9 @@ class OneLogin_Saml2_Logout_Request(object):
 
         :param session_index: SessionIndex that identifies the session of the user.
         :type session_index: string
+
+        :param nq: IDP Name Qualifier
+        :type: string
         """
         self.__settings = settings
         self.__error = None
@@ -70,7 +73,8 @@ class OneLogin_Saml2_Logout_Request(object):
                 name_id,
                 sp_name_qualifier,
                 name_id_format,
-                cert
+                cert,
+                nq=nq,
             )
 
             if session_index:

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -523,7 +523,7 @@ class OneLogin_Saml2_Utils(object):
         return formated_fingerprint.lower()
 
     @staticmethod
-    def generate_name_id(value, sp_nq, sp_format, cert=None, debug=False):
+    def generate_name_id(value, sp_nq, sp_format, cert=None, debug=False, nq=None):
         """
         Generates a nameID.
 
@@ -544,6 +544,9 @@ class OneLogin_Saml2_Utils(object):
 
         :returns: DOMElement | XMLSec nameID
         :rtype: string
+
+        :param nq: IDP Name Qualifier
+        :type: string
         """
 
         root = OneLogin_Saml2_XML.make_root("{%s}container" % OneLogin_Saml2_Constants.NS_SAML)
@@ -551,6 +554,8 @@ class OneLogin_Saml2_Utils(object):
         if sp_nq is not None:
             name_id.set('SPNameQualifier', sp_nq)
         name_id.set('Format', sp_format)
+        if nq is not None:
+            name_id.set('NameQualifier', nq)
         name_id.text = value
 
         if cert is not None:

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -459,6 +459,42 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         self.assertNotEqual('3311642371', OneLogin_Saml2_Utils.get_expire_time('PT360000S', '2074-12-10T04:39:31Z'))
         self.assertNotEqual('3311642371', OneLogin_Saml2_Utils.get_expire_time('PT360000S', 1418186371))
 
+    def _generate_name_id_element(self, name_qualifier):
+        name_id_value = 'value'
+        entity_id = 'sp-entity-id'
+        name_id_format = 'name-id-format'
+
+        raw_name_id = OneLogin_Saml2_Utils.generate_name_id(
+            name_id_value,
+            entity_id,
+            name_id_format,
+            nq=name_qualifier,
+        )
+        parser = etree.XMLParser(recover=True)
+        return etree.fromstring(raw_name_id, parser)
+
+    def testNameidGenerationIncludesNameQualifierAttribute(self):
+        """
+        Tests the inclusion of NameQualifier in the generateNameId method of the OneLogin_Saml2_Utils
+        """
+        idp_name_qualifier = 'idp-name-qualifier'
+        idp_name_qualifier_attribute = ('NameQualifier', idp_name_qualifier)
+
+        name_id = self._generate_name_id_element(idp_name_qualifier)
+
+        self.assertIn(idp_name_qualifier_attribute, name_id.attrib.items())
+
+    def testNameidGenerationDoesNotIncludeNameQualifierAttribute(self):
+        """
+        Tests the (not) inclusion of NameQualifier in the generateNameId method of the OneLogin_Saml2_Utils
+        """
+        idp_name_qualifier = None
+        not_expected_attribute = 'NameQualifier'
+
+        name_id = self._generate_name_id_element(idp_name_qualifier)
+
+        self.assertNotIn(not_expected_attribute, name_id.attrib.keys())
+
     def testGenerateNameIdWithSPNameQualifier(self):
         """
         Tests the generateNameId method of the OneLogin_Saml2_Utils


### PR DESCRIPTION
Per the suggestions in https://github.com/onelogin/python3-saml/issues/13, this should accomplish plumbing through NameQualifier into the saml Logout Request object.