### PR TITLE
Fixes Windows specific Unix date formatting bug

### DIFF
--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -9,7 +9,7 @@ Metadata class of OneLogin's Python Toolkit.
 
 """
 
-from time import gmtime, strftime
+from time import gmtime, strftime, time
 from datetime import datetime
 
 from onelogin.saml2 import compat
@@ -61,7 +61,7 @@ class OneLogin_Saml2_Metadata(object):
         :type organization: dict
         """
         if valid_until is None:
-            valid_until = int(datetime.now().strftime("%s")) + OneLogin_Saml2_Metadata.TIME_VALID
+            valid_until = int(time()) + OneLogin_Saml2_Metadata.TIME_VALID
         if not isinstance(valid_until, basestring):
             if isinstance(valid_until, datetime):
                 valid_until_time = valid_until.timetuple()

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -8,7 +8,6 @@ All rights reserved.
 Setting class of OneLogin's Python Toolkit.
 
 """
-from datetime import datetime
 from time import time
 import re
 from os.path import dirname, exists, join, sep

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -9,6 +9,7 @@ Setting class of OneLogin's Python Toolkit.
 
 """
 from datetime import datetime
+from time import time
 import re
 from os.path import dirname, exists, join, sep
 
@@ -720,7 +721,7 @@ class OneLogin_Saml2_Settings(object):
                     if valid_until:
                         valid_until = OneLogin_Saml2_Utils.parse_SAML_to_time(valid_until)
                     expire_time = OneLogin_Saml2_Utils.get_expire_time(cache_duration, valid_until)
-                    if expire_time is not None and int(datetime.now().strftime('%s')) > int(expire_time):
+                    if expire_time is not None and int(time()) > int(expire_time):
                         errors.append('expired_xml')
 
         # TODO: Validate Sign


### PR DESCRIPTION
Getting Unix time with strftime("%s") will only work on POSIX platforms, so not on Windows. time() is fine for both.