### PR TITLE
Handle RelayState in SLO SAMLResponse

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -139,6 +139,10 @@ class OneLogin_Saml2_Auth(object):
             elif not keep_local_session:
                 OneLogin_Saml2_Utils.delete_local_session(delete_session_cb)
 
+            if 'RelayState' in get_data:
+                return get_data['RelayState']
+
+
         elif get_data and 'SAMLRequest' in get_data:
             logout_request = OneLogin_Saml2_Logout_Request(self.__settings, get_data['SAMLRequest'])
             if not self.validate_request_signature(get_data):


### PR DESCRIPTION
Hello, 

I was integrating a standalone Angular2 application using the toolkit and in this case, once SLO finishes processing, I need the service to redirect back to the Service Provider app (which is not co-located with the authentication service) so that I could do some final book-keeping. 

I think that RelayState was not being handled correctly in auth.py in this use case, and I had to make the following change for this to work correctly. 

Submitting a pull request to validate that it is the correct fix, and if it might be useful for others, maybe it is worth merging back into the main line. 

Krishna 
 