### PR TITLE
Add option to raise response validation exceptions

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -212,11 +212,14 @@ class OneLogin_Saml2_Logout_Request(object):
             session_indexes.append(session_index_node.text)
         return session_indexes
 
-    def is_valid(self, request_data):
+    def is_valid(self, request_data, raises=False):
         """
         Checks if the Logout Request received is valid
         :param request_data: Request Data
         :type request_data: dict
+
+        :param raises: Optional argument. If true, the function will raise an exception as soon as first validation test fails
+        :type raises: bool
 
         :return: If the Logout Request is or not valid
         :rtype: boolean
@@ -274,6 +277,8 @@ class OneLogin_Saml2_Logout_Request(object):
             debug = self.__settings.is_debug_active()
             if debug:
                 print(err)
+            if raises:
+                raise
             return False
 
     def get_error(self):

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -63,11 +63,15 @@ class OneLogin_Saml2_Logout_Response(object):
         status = entries[0].attrib['Value']
         return status
 
-    def is_valid(self, request_data, request_id=None):
+    def is_valid(self, request_data, request_id=None, raises=False):
         """
         Determines if the SAML LogoutResponse is valid
         :param request_id: The ID of the LogoutRequest sent by this SP to the IdP
         :type request_id: string
+
+        :param raises: Optional argument. If true, the function will raise an exception as soon as first validation test fails
+        :type raises: bool
+
         :return: Returns if the SAML LogoutResponse is or not valid
         :rtype: boolean
         """
@@ -111,6 +115,8 @@ class OneLogin_Saml2_Logout_Response(object):
             debug = self.__settings.is_debug_active()
             if debug:
                 print(err)
+            if raises:
+                raise
             return False
 
     def __query(self, query):

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -47,7 +47,7 @@ class OneLogin_Saml2_Response(object):
             self.encrypted = True
             self.decrypted_document = self.__decrypt_assertion(decrypted_document)
 
-    def is_valid(self, request_data, request_id=None):
+    def is_valid(self, request_data, request_id=None, raises=False):
         """
         Validates the response object.
 
@@ -56,6 +56,9 @@ class OneLogin_Saml2_Response(object):
 
         :param request_id: Optional argument. The ID of the AuthNRequest sent by this SP to the IdP
         :type request_id: string
+
+        :param raises: Optional argument. If true, the function will raise an exception as soon as first validation test fails
+        :type raises: bool
 
         :returns: True if the SAML Response is valid, False if not
         :rtype: bool
@@ -226,6 +229,8 @@ class OneLogin_Saml2_Response(object):
             debug = self.__settings.is_debug_active()
             if debug:
                 print(err)
+            if raises:
+                raise
             return False
 
     def check_status(self):

--- a/tests/src/OneLogin/saml2_tests/logout_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_request_test.py
@@ -336,3 +336,19 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         request = request.replace('http://stuff.com/endpoints/endpoints/sls.php', current_url)
         logout_request5 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
         self.assertTrue(logout_request5.is_valid(request_data))
+
+    def testIsValidRaisesExceptionWhenRaisesArgumentIsTrue(self):
+        request = OneLogin_Saml2_Utils.b64encode('<xml>invalid</xml>')
+        request_data = {
+            'http_host': 'example.com',
+            'script_name': 'index.html',
+        }
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        settings.set_strict(True)
+
+        logout_request = OneLogin_Saml2_Logout_Request(settings, request)
+
+        self.assertFalse(logout_request.is_valid(request_data))
+
+        with self.assertRaises(Exception):
+            logout_request.is_valid(request_data, raises=True)

--- a/tests/src/OneLogin/saml2_tests/logout_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_request_test.py
@@ -121,10 +121,8 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         self.assertEqual(expected_name_id_data, name_id_data_2)
 
         request_2 = self.file_contents(join(self.data_path, 'logout_requests', 'logout_request_encrypted_nameid.xml'))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaisesRegexp(Exception, 'Key is required in order to decrypt the NameID'):
             OneLogin_Saml2_Logout_Request.get_nameid(request_2)
-            exception = context.exception
-            self.assertIn("Key is required in order to decrypt the NameID", str(exception))
 
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         key = settings.get_sp_key()
@@ -140,16 +138,12 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         encrypted_id_nodes = dom_2.getElementsByTagName('saml:EncryptedID')
         encrypted_data = encrypted_id_nodes[0].firstChild.nextSibling
         encrypted_id_nodes[0].removeChild(encrypted_data)
-        with self.assertRaises(Exception) as context:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the Logout Request'):
             OneLogin_Saml2_Logout_Request.get_nameid(dom_2.toxml(), key)
-            exception = context.exception
-            self.assertIn("Not NameID found in the Logout Request", str(exception))
 
         inv_request = self.file_contents(join(self.data_path, 'logout_requests', 'invalids', 'no_nameId.xml'))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the Logout Request'):
             OneLogin_Saml2_Logout_Request.get_nameid(inv_request)
-            exception = context.exception
-            self.assertIn("Not NameID found in the Logout Request", str(exception))
 
     def testGetNameId(self):
         """
@@ -160,10 +154,8 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         self.assertEqual(name_id, 'ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c')
 
         request_2 = self.file_contents(join(self.data_path, 'logout_requests', 'logout_request_encrypted_nameid.xml'))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaisesRegexp(Exception, 'Key is required in order to decrypt the NameID'):
             OneLogin_Saml2_Logout_Request.get_nameid(request_2)
-            exception = context.exception
-            self.assertIn("Key is required in order to decrypt the NameID", str(exception))
 
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         key = settings.get_sp_key()
@@ -242,12 +234,9 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         self.assertTrue(logout_request.is_valid(request_data))
 
         settings.set_strict(True)
-        try:
-            logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
-            valid = logout_request2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('Invalid issuer in the Logout Request', str(e))
+        logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        with self.assertRaisesRegexp(Exception, 'Invalid issuer in the Logout Request'):
+            logout_request2.is_valid(request_data, raises=True)
 
     def testIsInvalidDestination(self):
         """
@@ -264,12 +253,9 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         self.assertTrue(logout_request.is_valid(request_data))
 
         settings.set_strict(True)
-        try:
-            logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
-            valid = logout_request2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('The LogoutRequest was received at', str(e))
+        logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        with self.assertRaisesRegexp(Exception, 'The LogoutRequest was received at'):
+            logout_request2.is_valid(request_data, raises=True)
 
         dom = parseString(request)
         dom.documentElement.setAttribute('Destination', None)
@@ -298,12 +284,9 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         self.assertTrue(logout_request.is_valid(request_data))
 
         settings.set_strict(True)
-        try:
-            logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
-            valid = logout_request2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('Timing issues (please check your clock settings)', str(e))
+        logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        with self.assertRaisesRegexp(Exception, 'Timing issues \(please check your clock settings\)'):
+            logout_request2.is_valid(request_data, raises=True)
 
     def testIsValid(self):
         """

--- a/tests/src/OneLogin/saml2_tests/logout_response_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_response_test.py
@@ -201,11 +201,8 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Logout_Response(settings, message)
-        try:
-            valid = response_2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('Invalid issuer in the Logout Request', str(e))
+        with self.assertRaisesRegexp(Exception, 'Invalid issuer in the Logout Request'):
+            response_2.is_valid(request_data, raises=True)
 
     def testIsInValidDestination(self):
         """
@@ -226,11 +223,8 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Logout_Response(settings, message)
-        try:
-            valid = response_2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('The LogoutRequest was received at', str(e))
+        with self.assertRaisesRegexp(Exception, 'The LogoutRequest was received at'):
+            response_2.is_valid(request_data, raises=True)
 
         # Empty destination
         dom = parseString(OneLogin_Saml2_Utils.decode_base64_and_inflate(message))
@@ -264,11 +258,8 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Logout_Response(settings, message)
-        try:
-            valid = response_2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertIn('The LogoutRequest was received at', str(e))
+        with self.assertRaisesRegexp(Exception, 'The LogoutRequest was received at'):
+            response_2.is_valid(request_data, raises=True)
 
         plain_message = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(message))
         current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)

--- a/tests/src/OneLogin/saml2_tests/logout_response_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_response_test.py
@@ -277,3 +277,20 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
 
         response_3 = OneLogin_Saml2_Logout_Response(settings, message_3)
         self.assertTrue(response_3.is_valid(request_data))
+
+    def testIsValidRaisesExceptionWhenRaisesArgumentIsTrue(self):
+        message = OneLogin_Saml2_Utils.deflate_and_base64_encode('<xml>invalid</xml>')
+        request_data = {
+            'http_host': 'example.com',
+            'script_name': 'index.html',
+            'get_data': {}
+        }
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        settings.set_strict(True)
+
+        response = OneLogin_Saml2_Logout_Response(settings, message)
+
+        self.assertFalse(response.is_valid(request_data))
+
+        with self.assertRaises(Exception):
+            response.is_valid(request_data, raises=True)

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1349,3 +1349,18 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
                 'http_host': 'pitbulk.no-ip.org',
                 'script_name': 'newonelogin/demo1/index.php?acs'
             }))
+
+    def testIsValidRaisesExceptionWhenRaisesArgumentIsTrue(self):
+        """
+        Tests that the internal exception gets raised if the raise parameter
+        is True.
+        """
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        settings.set_strict(True)
+        xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_conditions.xml.base64'))
+        response = OneLogin_Saml2_Response(settings, xml)
+
+        self.assertFalse(response.is_valid(self.get_request_data()))
+
+        with self.assertRaises(Exception):
+            response.is_valid(self.get_request_data(), raises=True)

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -79,21 +79,15 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_4.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['security']['wantNameId'] = True
         settings = OneLogin_Saml2_Settings(json_settings)
 
         response_5 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_5.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['security']['wantNameId'] = False
         settings = OneLogin_Saml2_Settings(json_settings)
@@ -106,30 +100,21 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(json_settings)
 
         response_7 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_7.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['strict'] = True
         settings = OneLogin_Saml2_Settings(json_settings)
 
         xml_5 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'wrong_spnamequalifier.xml.base64'))
         response_8 = OneLogin_Saml2_Response(settings, xml_5)
-        try:
+        with self.assertRaisesRegexp(Exception, 'The SPNameQualifier value mistmatch the SP entityID value.'):
             response_8.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('The SPNameQualifier value mistmatch the SP entityID value.', str(e))
 
         xml_6 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'empty_nameid.xml.base64'))
         response_9 = OneLogin_Saml2_Response(settings, xml_6)
-        try:
+        with self.assertRaisesRegexp(Exception, 'An empty NameID value found'):
             response_9.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('An empty NameID value found', str(e))
 
     def testGetNameIdData(self):
         """
@@ -168,21 +153,15 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_4.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['security']['wantNameId'] = True
         settings = OneLogin_Saml2_Settings(json_settings)
 
         response_5 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_5.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['security']['wantNameId'] = False
         settings = OneLogin_Saml2_Settings(json_settings)
@@ -195,11 +174,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(json_settings)
 
         response_7 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_7.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['security']['wantNameId'] = False
         settings = OneLogin_Saml2_Settings(json_settings)
@@ -212,30 +188,21 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(json_settings)
 
         response_7 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Not NameID found in the assertion of the Response'):
             response_7.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', str(e))
 
         json_settings['strict'] = True
         settings = OneLogin_Saml2_Settings(json_settings)
 
         xml_5 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'wrong_spnamequalifier.xml.base64'))
         response_8 = OneLogin_Saml2_Response(settings, xml_5)
-        try:
+        with self.assertRaisesRegexp(Exception, 'The SPNameQualifier value mistmatch the SP entityID value.'):
             response_8.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('The SPNameQualifier value mistmatch the SP entityID value.', str(e))
 
         xml_6 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'empty_nameid.xml.base64'))
         response_9 = OneLogin_Saml2_Response(settings, xml_6)
-        try:
+        with self.assertRaisesRegexp(Exception, 'An empty NameID value found'):
             response_9.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('An empty NameID value found', str(e))
 
     def testCheckStatus(self):
         """
@@ -252,19 +219,13 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_2 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'status_code_responder.xml.base64'))
         response_2 = OneLogin_Saml2_Response(settings, xml_2)
-        try:
+        with self.assertRaisesRegexp(Exception, 'The status code of the Response was not Success, was Responder'):
             response_2.check_status()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('The status code of the Response was not Success, was Responder', str(e))
 
         xml_3 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'status_code_responer_and_msg.xml.base64'))
         response_3 = OneLogin_Saml2_Response(settings, xml_3)
-        try:
+        with self.assertRaisesRegexp(Exception, 'The status code of the Response was not Success, was Responder -> something_is_wrong'):
             response_3.check_status()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('The status code of the Response was not Success, was Responder -> something_is_wrong', str(e))
 
     def testCheckOneCondition(self):
         """
@@ -374,17 +335,13 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_issuer_response.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Issuer of the Response not found or multiple.'):
             response_4.get_issuers()
-        except Exception as e:
-            self.assertIn('Issuer of the Response not found or multiple.', str(e))
 
         xml_5 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_issuer_assertion.xml.base64'))
         response_5 = OneLogin_Saml2_Response(settings, xml_5)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Issuer of the Assertion not found or multiple.'):
             response_5.get_issuers()
-        except Exception as e:
-            self.assertIn('Issuer of the Assertion not found or multiple.', str(e))
 
     def testGetSessionIndex(self):
         """
@@ -535,11 +492,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_saml2.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('Reference validation failed', str(e))
+        with self.assertRaisesRegexp(Exception, 'Unsupported SAML version'):
+            response.is_valid(self.get_request_data(), raises=True)
 
     def testValidateID(self):
         """
@@ -549,11 +503,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_id.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('Missing ID attribute on SAML Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'Missing ID attribute on SAML Response'):
+            response.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidReference(self):
         """
@@ -582,11 +533,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response_2.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('Timing issues (please check your clock settings)', str(e))
+        with self.assertRaisesRegexp(Exception, 'Timing issues \(please check your clock settings\)'):
+            response_2.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidNoStatement(self):
         """
@@ -643,11 +591,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_key.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('Signature validation failed. SAML Response rejected', str(e))
+        with self.assertRaisesRegexp(Exception, 'Signature validation failed. SAML Response rejected'):
+            response.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidMultipleAssertions(self):
         """
@@ -658,11 +603,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'multiple_assertions.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('SAML Response must contain 1 assertion', str(e))
+        with self.assertRaisesRegexp(Exception, 'SAML Response must contain 1 assertion'):
+            response.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidEncAttrs(self):
         """
@@ -677,11 +619,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Response(settings, xml)
-        try:
-            valid = response_2.is_valid(self.get_request_data())
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('There is an EncryptedAttribute in the Response and this SP not support them', str(e))
+        with self.assertRaisesRegexp(Exception, 'There is an EncryptedAttribute in the Response and this SP not support them'):
+            response_2.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidDuplicatedAttrs(self):
         """
@@ -691,11 +630,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'duplicated_attributes.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        try:
+        with self.assertRaisesRegexp(Exception, 'Found an Attribute element with duplicated Name'):
             response.get_attributes()
-            self.assertFalse(True)
-        except Exception as e:
-            self.assertEqual('Found an Attribute element with duplicated Name', str(e))
 
     def testIsInValidDestination(self):
         """
@@ -786,18 +722,12 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_3 = OneLogin_Saml2_Response(settings, message)
-        try:
-            valid = response_3.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('is not a valid audience for this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'Invalid issuer in the Assertion/Response'):
+            response_3.is_valid(request_data, raises=True)
 
         response_4 = OneLogin_Saml2_Response(settings, message_2)
-        try:
-            valid = response_4.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('is not a valid audience for this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'Invalid issuer in the Assertion/Response'):
+            response_4.is_valid(request_data, raises=True)
 
     def testIsInValidSessionIndex(self):
         """
@@ -821,11 +751,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Response(settings, message)
-        try:
-            valid = response_2.is_valid(request_data)
-            self.assertFalse(valid)
-        except Exception as e:
-            self.assertEqual('The attributes have expired, based on the SessionNotOnOrAfter of the AttributeStatement of this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'The attributes have expired, based on the SessionNotOnOrAfter of the AttributeStatement of this Response'):
+            response_2.is_valid(request_data, raises=True)
 
     def testDatetimeWithMiliseconds(self):
         """
@@ -915,40 +842,28 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, message)
-        try:
-            self.assertFalse(response.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response.is_valid(request_data, raises=True)
 
         response_2 = OneLogin_Saml2_Response(settings, message_2)
-        try:
-            self.assertFalse(response_2.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response_2.is_valid(request_data, raises=True)
 
         response_3 = OneLogin_Saml2_Response(settings, message_3)
-        try:
-            self.assertFalse(response_3.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response_3.is_valid(request_data, raises=True)
 
         response_4 = OneLogin_Saml2_Response(settings, message_4)
-        try:
-            self.assertFalse(response_4.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response_4.is_valid(request_data, raises=True)
 
         response_5 = OneLogin_Saml2_Response(settings, message_5)
-        try:
-            self.assertFalse(response_5.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response_5.is_valid(request_data, raises=True)
 
         response_6 = OneLogin_Saml2_Response(settings, message_6)
-        try:
-            self.assertFalse(response_6.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('A valid SubjectConfirmation was not found on this Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'A valid SubjectConfirmation was not found on this Response'):
+            response_6.is_valid(request_data, raises=True)
 
     def testIsInValidRequestId(self):
         """
@@ -973,10 +888,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, message)
-        try:
-            self.assertFalse(response.is_valid(request_data, request_id))
-        except Exception as e:
-            self.assertEqual('The InResponseTo of the Response', str(e))
+        with self.assertRaisesRegexp(Exception, 'The InResponseTo of the Response'):
+            response.is_valid(request_data, request_id, raises=True)
 
         valid_request_id = '_57bcbf70-7b1f-012e-c821-782bcb13bb38'
         response.is_valid(request_data, valid_request_id)
@@ -1020,10 +933,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings_info['security']['wantAssertionsSigned'] = True
         settings_4 = OneLogin_Saml2_Settings(settings_info)
         response_4 = OneLogin_Saml2_Response(settings_4, message)
-        try:
-            self.assertFalse(response_4.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('The Assertion of the Response is not signed and the SP require it', str(e))
+        with self.assertRaisesRegexp(Exception, 'The Assertion of the Response is not signed and the SP require it'):
+            response_4.is_valid(request_data, raises=True)
 
         settings_info['security']['wantAssertionsSigned'] = False
         settings_info['strict'] = False
@@ -1050,10 +961,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings_info['security']['wantMessagesSigned'] = True
         settings_8 = OneLogin_Saml2_Settings(settings_info)
         response_8 = OneLogin_Saml2_Response(settings_8, message)
-        try:
-            self.assertFalse(response_8.is_valid(request_data))
-        except Exception as e:
-            self.assertEqual('The Message of the Response is not signed and the SP require it', str(e))
+        with self.assertRaisesRegexp(Exception, 'The Message of the Response is not signed and the SP require it'):
+            response_8.is_valid(request_data, raises=True)
 
     def testIsInValidEncIssues(self):
         """
@@ -1134,10 +1043,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         xml = self.file_contents(join(self.data_path, 'responses', 'valid_response.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
 
-        try:
-            self.assertFalse(response.is_valid(self.get_request_data()))
-        except Exception as e:
-            self.assertIn('openssl_x509_read(): supplied parameter cannot be', str(e))
+        with self.assertRaisesRegexp(Exception, 'failed to load key'):
+            response.is_valid(self.get_request_data(), raises=True)
 
     def testIsInValidCert2(self):
         """

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -279,7 +279,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, xml)
         self.assertFalse(response.is_valid(self.get_request_data()))
-        self.assertEquals('The Assertion must include a Conditions element', response.get_error())
+        self.assertEqual('The Assertion must include a Conditions element', response.get_error())
 
         xml_2 = self.file_contents(join(self.data_path, 'responses', 'valid_response.xml.base64'))
         response_2 = OneLogin_Saml2_Response(settings, xml_2)
@@ -298,7 +298,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, xml)
         self.assertFalse(response.is_valid(self.get_request_data()))
-        self.assertEquals('The Assertion must include an AuthnStatement element', response.get_error())
+        self.assertEqual('The Assertion must include an AuthnStatement element', response.get_error())
 
         xml_2 = self.file_contents(join(self.data_path, 'responses', 'valid_response.xml.base64'))
         response_2 = OneLogin_Saml2_Response(settings, xml_2)
@@ -724,7 +724,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         message_3 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'empty_destination.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, message_3)
         self.assertFalse(response_4.is_valid(self.get_request_data()))
-        self.assertEquals('The response has an empty Destination value', response_4.get_error())
+        self.assertEqual('The response has an empty Destination value', response_4.get_error())
 
         # No Destination
         dom.firstChild.removeAttribute('Destination')


### PR DESCRIPTION
The current `OneLogin_Saml2_Response.is_valid` always collects the first raised exceptions and creates the error message from the exception content. I am using Raven (+ Sentry) to track all unhandled exceptions, so I would rather have the function just raise the first found validation error.  When the exception is raised from the problem source Raven is able to capture local variables from the exception context. In my use case IdP:s can be dynamically added/removed/modified during the program runtime, so getting all the exception information is important to me.

This PR adds an optional `raises` argument to `OneLogin_Saml2_Response.is_valid`. When the argument is truthy, first found exception gets raised. As the option is optional this change is completely backwards compatible.

As I wrote test for this feature I noticed some oddness in some test code: 
 - Many tests contained code to test for raised exceptions event thou the functions didn't raise any exceptions. Fixed in cd2a6b4.
 - Some tests used `self.assertFalse(True)` method to make sure that the exception was thrown. I refactored these tests in a9997f7.
 - Some tests didn't make sure that the tested function actually raised the expected error. Fixed in 	c007ca7.
