### PR TITLE
Force xmlsec less than version 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     test_suite='tests',
     install_requires=[
         'isodate>=0.5.0',
-        'xmlsec>=0.6.0'
+        'xmlsec>=0.6.0,<1'
     ],
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
     extras_require={


### PR DESCRIPTION
xmlsec 1.0.1 is newly released and breaks when building. Force xmlsec <1 so this can still install.

```
12:59:26 Collecting xmlsec>=0.6.0 (from python3-saml==1.2.3->merchant-api==1.23b4->-r requirements.txt (line 8))
12:59:26   Using cached xmlsec-1.0.1.tar.gz
12:59:26     Complete output from command python setup.py egg_info:
12:59:26     Traceback (most recent call last):
12:59:26       File "<string>", line 1, in <module>
12:59:26       File "/tmp/pip-build-jqqwzjnw/xmlsec/setup.py", line 5, in <module>
12:59:26         import pkgconfig
12:59:26     ImportError: No module named 'pkgconfig'
```