### PR TITLE
Update demo-django to Django 1.11

### DIFF
--- a/demo-django/demo/settings.py
+++ b/demo-django/demo/settings.py
@@ -10,8 +10,8 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
@@ -22,10 +22,7 @@ SECRET_KEY = '0c7216)gs^ne$%3+je20zuo+g0&^6yb@e68qdr!^!r0hmb-6y+'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -38,7 +35,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
@@ -50,7 +47,6 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'demo.urls'
 
 WSGI_APPLICATION = 'demo.wsgi.application'
-
 
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases
@@ -75,16 +71,26 @@ USE_L10N = True
 
 USE_TZ = True
 
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
-
 STATIC_URL = '/static/'
 
 SAML_FOLDER = os.path.join(BASE_DIR, 'saml')
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.file'
 
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates'),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')]
+        ,
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': True,
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/demo-django/demo/urls.py
+++ b/demo-django/demo/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
-
+from django.conf.urls import url
 from django.contrib import admin
+from .views import attrs, index, metadata
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', 'demo.views.index', name='index'),
-    url(r'^attrs/$', 'demo.views.attrs', name='attrs'),
-    url(r'^metadata/$', 'demo.views.metadata', name='metadata'),
-)
+urlpatterns = [
+    url(r'^$', index, name='index'),
+    url(r'^attrs/$', attrs, name='attrs'),
+    url(r'^metadata/$', metadata, name='metadata'),
+]

--- a/demo-django/demo/views.py
+++ b/demo-django/demo/views.py
@@ -78,13 +78,13 @@ def index(request):
         if len(request.session['samlUserdata']) > 0:
             attributes = request.session['samlUserdata'].items()
 
+    context = RequestContext(request, {'errors': errors,
+                                       'not_auth_warn': not_auth_warn,
+                                       'success_slo': success_slo,
+                                       'attributes': attributes,
+                                       'paint_logout': paint_logout}).flatten()
     return render_to_response('index.html',
-                              {'errors': errors,
-                               'not_auth_warn': not_auth_warn,
-                               'success_slo': success_slo,
-                               'attributes': attributes,
-                               'paint_logout': paint_logout},
-                              context_instance=RequestContext(request))
+                              context=context)
 
 
 def attrs(request):
@@ -97,9 +97,8 @@ def attrs(request):
             attributes = request.session['samlUserdata'].items()
 
     return render_to_response('attrs.html',
-                              {'paint_logout': paint_logout,
-                               'attributes': attributes},
-                              context_instance=RequestContext(request))
+                              context=RequestContext(request, {'paint_logout': paint_logout,
+                                                               'attributes': attributes}).flatten())
 
 
 def metadata(request):

--- a/demo-django/demo/views.py
+++ b/demo-django/demo/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (HttpResponse, HttpResponseRedirect,
                          HttpResponseServerError)
 from django.shortcuts import render_to_response

--- a/demo-django/requirements.txt
+++ b/demo-django/requirements.txt
@@ -1,1 +1,2 @@
-Django==1.6.5
+Django==1.11
+python3-saml


### PR DESCRIPTION
I've updated the demo-django example to use Django 1.11. This mostly involved rewriting some settings and updating deprecated functions.