### PR TITLE
Added AuthnContext XML Template

### DIFF
--- a/src/onelogin/saml2/xml_templates.py
+++ b/src/onelogin/saml2/xml_templates.py
@@ -155,3 +155,8 @@ class OneLogin_Saml2_Templates(object):
         </saml:AttributeStatement>
     </saml:Assertion>
 </samlp:Response>"""
+
+    AUTHN_CONTEXT = """\
+                  <saml:AuthnContext>
+                      <saml:AuthnContextClassRef>%(context_class)s</saml:AuthnContextClassRef>
+                  </saml:AuthnContext>"""


### PR DESCRIPTION
This PR adds an `AUTHN_CONTEXT` template to the set of XML templates. This is needed to create a complete `RESPONSE` template by filling in the `authn_context` block. See: https://github.com/onelogin/python3-saml/blob/master/src/onelogin/saml2/xml_templates.py#L151

The template has the correct whitespace to generate a "pretty" XML response. The `context_class` should be one of `urn:oasis:names:tc:SAML:2.0:ac:classes`, e.g. "urn:oasis:names:tc:SAML:2.0:ac:classes:Password". These constants are already defined and available for use here:
https://github.com/onelogin/python3-saml/blob/master/src/onelogin/saml2/constants.py#L57-L63
