### PR TITLE
Fix signature tag position in the SP metadata

### DIFF
--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -742,7 +742,7 @@ class OneLogin_Saml2_Utils(object):
             issuer = issuer[0]
             issuer.addnext(signature)
         else:
-            elem[0].insert(0, signature)
+            elem.insert(0, signature)
 
         elem_id = elem.get('ID', None)
         if elem_id:

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -13,6 +13,7 @@ from onelogin.saml2 import compat
 from onelogin.saml2.metadata import OneLogin_Saml2_Metadata
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
+from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
 
 
 class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
@@ -247,6 +248,10 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
         self.assertIn('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', signed_metadata_2)
         self.assertIn('<ds:Reference', signed_metadata_2)
         self.assertIn('<ds:KeyInfo>\n<ds:X509Data>\n<ds:X509Certificate>', signed_metadata_2)
+
+        root = OneLogin_Saml2_XML.to_etree(signed_metadata_2)
+        first_child = OneLogin_Saml2_XML.query(root, '/md:EntityDescriptor/*[1]')[0]
+        self.assertEqual('{http://www.w3.org/2000/09/xmldsig#}Signature', first_child.tag)
 
     def testAddX509KeyDescriptors(self):
         """

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -774,7 +774,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         xml_metadata_signed = compat.to_string(OneLogin_Saml2_Utils.add_sign(xml_metadata, key, cert))
         self.assertIn('<ds:SignatureValue>', xml_metadata_signed)
         res_8 = parseString(xml_metadata_signed)
-        ds_signature_8 = res_8.firstChild.firstChild.nextSibling.firstChild.nextSibling
+        ds_signature_8 = res_8.firstChild.firstChild.nextSibling
         self.assertIn('ds:Signature', ds_signature_8.tagName)
 
     def testAddSignCheckAlg(self):


### PR DESCRIPTION
The `OneLogin_Saml2_Utils.add_sign` method added the `Signature` element inside the first element of the `EntityDescriptor` when metadata signing was enabled.

The SAML 2 metadata schema says that the signature tag must be the first element inside the `EntityDescriptor`.