### PR TITLE
Add support for post binding on LogoutResponse

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -140,8 +140,13 @@ class OneLogin_Saml2_Auth(object):
         self.__error_reason = None
 
         get_data = 'get_data' in self.__request_data and self.__request_data['get_data']
+        post_data = 'post_data' in self._OneLogin_Saml2_Auth__request_data and self._OneLogin_Saml2_Auth__request_data['post_data']
+        method = 'redirect'
+        if post_data:
+            get_data = post_data
+            method = 'post'
         if get_data and 'SAMLResponse' in get_data:
-            logout_response = OneLogin_Saml2_Logout_Response(self.__settings, get_data['SAMLResponse'])
+            logout_response = OneLogin_Saml2_Logout_Response(self.__settings, get_data['SAMLResponse'], method)
             self.__last_response = logout_response.get_xml()
             if not self.validate_response_signature(get_data):
                 self.__errors.append('invalid_logout_response_signature')
@@ -171,7 +176,7 @@ class OneLogin_Saml2_Auth(object):
 
                 in_response_to = logout_request.id
                 self.__last_message_id = logout_request.id
-                response_builder = OneLogin_Saml2_Logout_Response(self.__settings)
+                response_builder = OneLogin_Saml2_Logout_Response(self.__settings, method=method)
                 response_builder.build(in_response_to)
                 self.__last_response = response_builder.get_xml()
                 logout_response = response_builder.get_response()

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -23,7 +23,12 @@ class OneLogin_Saml2_Logout_Response(object):
 
     """
 
-    def __init__(self, settings, response=None):
+    METHOD_RESOLVERS = {
+        'redirect': 'decode_base64_and_inflate',
+        'post': 'b64decode'
+    }
+
+    def __init__(self, settings, response=None, method='redirect'):
         """
         Constructs a Logout Response object (Initialize params from settings
         and if provided load the Logout Response.
@@ -38,7 +43,11 @@ class OneLogin_Saml2_Logout_Response(object):
         self.id = None
 
         if response is not None:
-            self.__logout_response = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(response))
+            resolver = self.METHOD_RESOLVERS.get(method, None)
+            if resolver is None:
+                raise ValueError("Wrong value %r for argument 'method'." % method)
+            decoded_response = getattr(OneLogin_Saml2_Utils, resolver)(response)
+            self.__logout_response = compat.to_string(decoded_response)
             self.document = OneLogin_Saml2_XML.to_etree(self.__logout_response)
             self.id = self.document.get('ID', None)
 


### PR DESCRIPTION
This PR add the support for HTTP-POST binding on singleLogoutService endpoint.

I think your library is very nice and well tested, it will be useful for a lot of dev having this feature :).