### PR TITLE
Preserve xmlns:xs namespace when signing and serializing responses

### DIFF
--- a/src/onelogin/saml2/constants.py
+++ b/src/onelogin/saml2/constants.py
@@ -47,6 +47,24 @@ class OneLogin_Saml2_Constants(object):
     NS_XENC = 'http://www.w3.org/2001/04/xmlenc#'
     NS_DS = 'http://www.w3.org/2000/09/xmldsig#'
 
+    # Namespace Prefixes
+    NS_PREFIX_SAML = 'saml'
+    NS_PREFIX_SAMLP = 'samlp'
+    NS_PREFIX_MD = 'md'
+    NS_PREFIX_XS = 'xs'
+    NS_PREFIX_XSI = 'xsi'
+    NS_PREFIX_XENC = 'xenc'
+    NS_PREFIX_DS = 'ds'
+
+    # Prefix:Namespace Mappings
+    NSMAP = {
+        NS_PREFIX_SAMLP: NS_SAMLP,
+        NS_PREFIX_SAML: NS_SAML,
+        NS_PREFIX_DS: NS_DS,
+        NS_PREFIX_XENC: NS_XENC,
+        NS_PREFIX_MD: NS_MD
+    }
+
     # Bindings
     BINDING_HTTP_POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
     BINDING_HTTP_REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
@@ -75,15 +93,6 @@ class OneLogin_Saml2_Constants(object):
     STATUS_NO_PASSIVE = 'urn:oasis:names:tc:SAML:2.0:status:NoPassive'
     STATUS_PARTIAL_LOGOUT = 'urn:oasis:names:tc:SAML:2.0:status:PartialLogout'
     STATUS_PROXY_COUNT_EXCEEDED = 'urn:oasis:names:tc:SAML:2.0:status:ProxyCountExceeded'
-
-    # Namespaces
-    NSMAP = {
-        'samlp': NS_SAMLP,
-        'saml': NS_SAML,
-        'ds': NS_DS,
-        'xenc': NS_XENC,
-        'md': NS_MD
-    }
 
     # Sign & Crypto
     SHA1 = 'http://www.w3.org/2000/09/xmldsig#sha1'

--- a/src/onelogin/saml2/xml_utils.py
+++ b/src/onelogin/saml2/xml_utils.py
@@ -31,27 +31,6 @@ class OneLogin_Saml2_XML(object):
     make_root = staticmethod(etree.Element)
     make_child = staticmethod(etree.SubElement)
 
-    @staticmethod
-    def cleanup_namespaces(tree_or_element, top_nsmap=None, keep_ns_prefixes=None):
-        """
-        Keeps the xmlns:xs namespace intact when etree.cleanup_namespaces is invoked.
-        :param tree_or_element: An XML tree or element
-        :type tree_or_element: etree.Element
-        :param top_nsmap: A mapping from namespace prefixes to namespace URIs
-        :type top_nsmap: dict
-        :param keep_ns_prefixes: List of prefixes that should not be removed as part of the cleanup
-        :type keep_ns_prefixes: list
-        :returns: An XML tree or element
-        :rtype: etree.Element
-        """
-        all_prefixes_to_keep = [
-            OneLogin_Saml2_Constants.NS_PREFIX_XS
-        ]
-
-        if keep_ns_prefixes:
-            all_prefixes_to_keep = list(set(all_prefixes_to_keep.extend(keep_ns_prefixes)))
-
-        return etree.cleanup_namespaces(tree_or_element, keep_ns_prefixes=all_prefixes_to_keep)
 
     @staticmethod
     def to_string(xml, **kwargs):
@@ -143,6 +122,28 @@ class OneLogin_Saml2_XML(object):
             return dom.xpath(query, namespaces=OneLogin_Saml2_Constants.NSMAP)
         else:
             return context.xpath(query, namespaces=OneLogin_Saml2_Constants.NSMAP)
+
+    @staticmethod
+    def cleanup_namespaces(tree_or_element, top_nsmap=None, keep_ns_prefixes=None):
+        """
+        Keeps the xmlns:xs namespace intact when etree.cleanup_namespaces is invoked.
+        :param tree_or_element: An XML tree or element
+        :type tree_or_element: etree.Element
+        :param top_nsmap: A mapping from namespace prefixes to namespace URIs
+        :type top_nsmap: dict
+        :param keep_ns_prefixes: List of prefixes that should not be removed as part of the cleanup
+        :type keep_ns_prefixes: list
+        :returns: An XML tree or element
+        :rtype: etree.Element
+        """
+        all_prefixes_to_keep = [
+            OneLogin_Saml2_Constants.NS_PREFIX_XS
+        ]
+
+        if keep_ns_prefixes:
+            all_prefixes_to_keep = list(set(all_prefixes_to_keep.extend(keep_ns_prefixes)))
+
+        return etree.cleanup_namespaces(tree_or_element, keep_ns_prefixes=all_prefixes_to_keep)
 
     @staticmethod
     def extract_tag_text(xml, tagname):

--- a/src/onelogin/saml2/xml_utils.py
+++ b/src/onelogin/saml2/xml_utils.py
@@ -31,7 +31,6 @@ class OneLogin_Saml2_XML(object):
     make_root = staticmethod(etree.Element)
     make_child = staticmethod(etree.SubElement)
 
-
     @staticmethod
     def to_string(xml, **kwargs):
         """

--- a/src/onelogin/saml2/xml_utils.py
+++ b/src/onelogin/saml2/xml_utils.py
@@ -30,7 +30,28 @@ class OneLogin_Saml2_XML(object):
     dump = staticmethod(etree.dump)
     make_root = staticmethod(etree.Element)
     make_child = staticmethod(etree.SubElement)
-    cleanup_namespaces = staticmethod(etree.cleanup_namespaces)
+
+    @staticmethod
+    def cleanup_namespaces(tree_or_element, top_nsmap=None, keep_ns_prefixes=None):
+        """
+        Keeps the xmlns:xs namespace intact when etree.cleanup_namespaces is invoked.
+        :param tree_or_element: An XML tree or element
+        :type tree_or_element: etree.Element
+        :param top_nsmap: A mapping from namespace prefixes to namespace URIs
+        :type top_nsmap: dict
+        :param keep_ns_prefixes: List of prefixes that should not be removed as part of the cleanup
+        :type keep_ns_prefixes: list
+        :returns: An XML tree or element
+        :rtype: etree.Element
+        """
+        all_prefixes_to_keep = [
+            OneLogin_Saml2_Constants.NS_PREFIX_XS
+        ]
+
+        if keep_ns_prefixes:
+            all_prefixes_to_keep = list(set(all_prefixes_to_keep.extend(keep_ns_prefixes)))
+
+        return etree.cleanup_namespaces(tree_or_element, keep_ns_prefixes=all_prefixes_to_keep)
 
     @staticmethod
     def to_string(xml, **kwargs):

--- a/tests/pep8.rc
+++ b/tests/pep8.rc
@@ -1,3 +1,3 @@
 [pep8]
-ignore = E501
+ignore = E501,E731
 max-line-length = 160


### PR DESCRIPTION
Fix for: https://github.com/onelogin/python3-saml/issues/76

This PR overrides the `OneLogin_Saml2_XML` static method `cleanup_namspaces`, which is directly invoking `etree.cleanup_namespaces`. I added a whitelist of namespaces that should not be cleaned from an element before serialization into XML. This preserves the `xmlns:xs` namespace that's specifically needed to validate the schema of a SAML Response's attributes.

I also added some additional namespace prefix constants (now grouped with the other namespace constants) in `OneLogin_Saml2_Constants`.