### PR TITLE
Support multiple assertion consumer services (#102)

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -318,7 +318,7 @@ class OneLogin_Saml2_Auth(object):
         """
         return self.__last_assertion_id
 
-    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True):
+    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, acs_index=None):
         """
         Initiates the SSO process.
 
@@ -334,10 +334,13 @@ class OneLogin_Saml2_Auth(object):
         :param set_nameid_policy: Optional argument. When true the AuthNRequest will set a nameIdPolicy element.
         :type set_nameid_policy: bool
 
+        :param acs_index: Optional argument. The index of the assertionConsumerService to use, if multiple were specified.
+        :type acs_index: int
+
         :returns: Redirection URL
         :rtype: string
         """
-        authn_request = OneLogin_Saml2_Authn_Request(self.__settings, force_authn, is_passive, set_nameid_policy)
+        authn_request = OneLogin_Saml2_Authn_Request(self.__settings, force_authn, is_passive, set_nameid_policy, acs_index)
         self.__last_request = authn_request.get_xml()
         self.__last_request_id = authn_request.get_id()
 

--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -173,6 +173,21 @@ class OneLogin_Saml2_Metadata(object):
                     'requested_attribute_str': '\n'.join(requested_attribute_data)
                 }
 
+        str_assertion_consumers = ''
+        if isinstance(sp['assertionConsumerService'], dict):
+            str_assertion_consumers += OneLogin_Saml2_Templates.MD_ASSERTION_CONSUMER_SERVICE % {
+                'binding': sp['assertionConsumerService']['binding'],
+                'location': sp['assertionConsumerService']['url'],
+                'index': sp['assertionConsumerService'].get('index', '1')
+            }
+        else:
+            for idx, acs in enumerate(sp['assertionConsumerService']):
+                str_assertion_consumers += OneLogin_Saml2_Templates.MD_ASSERTION_CONSUMER_SERVICE % {
+                    'binding': acs['binding'],
+                    'location': acs['url'],
+                    'index': acs.get('index', compat.to_string(idx))
+                }
+
         metadata = OneLogin_Saml2_Templates.MD_ENTITY_DESCRIPTOR % \
             {
                 'valid': ('validUntil="%s"' % valid_until_str) if valid_until_str else '',
@@ -181,8 +196,7 @@ class OneLogin_Saml2_Metadata(object):
                 'authnsign': str_authnsign,
                 'wsign': str_wsign,
                 'name_id_format': sp['NameIDFormat'],
-                'binding': sp['assertionConsumerService']['binding'],
-                'location': sp['assertionConsumerService']['url'],
+                'assertion_consumers': str_assertion_consumers,
                 'sls': sls,
                 'organization': str_organization,
                 'contacts': str_contacts,

--- a/src/onelogin/saml2/xml_templates.py
+++ b/src/onelogin/saml2/xml_templates.py
@@ -80,6 +80,11 @@ class OneLogin_Saml2_Templates(object):
 %(attr_cs_desc)s%(requested_attribute_str)s
         </md:AttributeConsumingService>\n"""
 
+    MD_ASSERTION_CONSUMER_SERVICE = """\
+        <md:AssertionConsumerService Binding="%(binding)s"
+                                     Location="%(location)s"
+                                     index="%(index)s" />\n"""
+
     MD_ENTITY_DESCRIPTOR = """\
 <?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
@@ -88,9 +93,7 @@ class OneLogin_Saml2_Templates(object):
                      entityID="%(entity_id)s">
     <md:SPSSODescriptor AuthnRequestsSigned="%(authnsign)s" WantAssertionsSigned="%(wsign)s" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 %(sls)s        <md:NameIDFormat>%(name_id_format)s</md:NameIDFormat>
-        <md:AssertionConsumerService Binding="%(binding)s"
-                                     Location="%(location)s"
-                                     index="1" />
+        %(assertion_consumers)s
 %(attribute_consuming_service)s    </md:SPSSODescriptor>
 %(organization)s
 %(contacts)s

--- a/tests/settings/settings9.json
+++ b/tests/settings/settings9.json
@@ -1,0 +1,58 @@
+{
+    "strict": false,
+    "debug": false,
+    "custom_base_path": "../../../tests/data/customPath/",
+    "sp": {
+        "entityId": "http://stuff.com/endpoints/metadata.php",
+        "assertionConsumerService": [
+            {
+                "url": "http://stuff.com/endpoints/endpoints/acs.php",
+                "index": "123"
+            },
+            {
+                "url": "http://stuff.com/endpoints/endpoints/acs2.php",
+                "index": "456"
+            },
+            {
+                "url": "http://stuff.com/endpoints/endpoints/acs3.php",
+                "index": "789"
+            }
+        ],
+        "singleLogoutService": {
+            "url": "http://stuff.com/endpoints/endpoints/sls.php"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+    },
+    "idp": {
+        "entityId": "http://idp.example.com/",
+        "singleSignOnService": {
+            "url": "http://idp.example.com/SSOService.php"
+        },
+        "singleLogoutService": {
+            "url": "http://idp.example.com/SingleLogoutService.php"
+        },
+        "x509cert": "MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo"
+    },
+    "security": {
+        "authnRequestsSigned": false,
+        "wantAssertionsSigned": false,
+        "signMetadata": false
+    },
+    "contactPerson": {
+        "technical": {
+            "givenName": "technical_name",
+            "emailAddress": "technical@example.com"
+        },
+        "support": {
+            "givenName": "support_name",
+            "emailAddress": "support@example.com"
+        }
+    },
+    "organization": {
+        "en-US": {
+            "name": "sp_test",
+            "displayname": "SP test",
+            "url": "http://sp.example.com"
+        }
+    }
+}

--- a/tests/src/OneLogin/saml2_tests/authn_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/authn_request_test.py
@@ -339,3 +339,14 @@ class OneLogin_Saml2_Authn_Request_Test(unittest.TestCase):
         inflated = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(authn_request_encoded))
 
         self.assertRegex(inflated, 'AttributeConsumingServiceIndex="1"')
+
+    def testMultipleAssertionConsumerServices(self):
+        settings_data = self.loadSettingsJSON('settings9.json')
+        settings = OneLogin_Saml2_Settings(settings_data)
+        self.assertEqual(len(settings.get_errors()), 0)
+
+        authn_request = OneLogin_Saml2_Authn_Request(settings, acs_index=456)
+        authn_request_encoded = authn_request.get_request()
+        inflated = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(authn_request_encoded))
+
+        self.assertRegex(inflated, 'AssertionConsumerServiceURL="http://stuff.com/endpoints/endpoints/acs2.php">')


### PR DESCRIPTION
Implementation that handles assertionConsumerService as both dict and list, with passing tests.