### PR TITLE
Add flexibility to the slo implementation so compression isn't required.

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -126,7 +126,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SAML_RESPONSE_NOT_FOUND
             )
 
-    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None):
+    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None, ignore_zip=False):
         """
         Process the SAML Logout Response / Logout Request sent by the IdP.
 
@@ -143,7 +143,7 @@ class OneLogin_Saml2_Auth(object):
 
         get_data = 'get_data' in self.__request_data and self.__request_data['get_data']
         if get_data and 'SAMLResponse' in get_data:
-            logout_response = OneLogin_Saml2_Logout_Response(self.__settings, get_data['SAMLResponse'])
+            logout_response = OneLogin_Saml2_Logout_Response(self.__settings, get_data['SAMLResponse'], ignore_zip=ignore_zip)
             self.__last_response = logout_response.get_xml()
             if not self.validate_response_signature(get_data):
                 self.__errors.append('invalid_logout_response_signature')

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -23,7 +23,7 @@ class OneLogin_Saml2_Logout_Response(object):
 
     """
 
-    def __init__(self, settings, response=None):
+    def __init__(self, settings, response=None, ignore_zip=False):
         """
         Constructs a Logout Response object (Initialize params from settings
         and if provided load the Logout Response.
@@ -38,7 +38,7 @@ class OneLogin_Saml2_Logout_Response(object):
         self.id = None
 
         if response is not None:
-            self.__logout_response = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(response))
+            self.__logout_response = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(response, ignore_zip))
             self.document = OneLogin_Saml2_XML.to_etree(self.__logout_response)
             self.id = self.document.get('ID', None)
 


### PR DESCRIPTION
We don't currently have a way of switching off compression in SLO, please give us the flexibility. Some providers aren't compressing, and it's throwing an error and there is no way to compensate.