### PR TITLE
TravisCI: Py3.7 & flake8 is a superset of pep8 and pyflakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
   - '3.5'
   - '3.6'
 
+matrix:
+  include:
+    - python: '3.7'
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq swig python-dev libxml2-dev libxmlsec1-dev
@@ -15,7 +20,6 @@ script:
   - 'coverage run --source=src/onelogin/saml2 --rcfile=tests/coverage.rc setup.py test'
   - 'coverage report -m --rcfile=tests/coverage.rc'
 # - 'pylint src/onelogin/saml2 --rcfile=tests/pylint.rc'
-  - 'pep8 tests/src/OneLogin/saml2_tests/*.py demo-flask/*.py demo-django/*.py src/onelogin/saml2/*.py --config=tests/pep8.rc'
-  - 'pyflakes src/onelogin/saml2 demo-django demo-flask tests/src/OneLogin/saml2_tests'
+  - 'flake8 .'
 
 after_success: 'coveralls'

--- a/demo-django/demo/settings.py
+++ b/demo-django/demo/settings.py
@@ -80,8 +80,7 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.file'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')]
-        ,
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'debug': True,

--- a/demo-django/demo/views.py
+++ b/demo-django/demo/views.py
@@ -83,7 +83,7 @@ def index(request):
             attributes = request.session['samlUserdata'].items()
 
     return render(request, 'index.html', {'errors': errors, 'error_reason': error_reason, 'not_auth_warn': not_auth_warn, 'success_slo': success_slo,
-                                          'attributes': attributes, 'paint_logout': paint_logout})        
+                                          'attributes': attributes, 'paint_logout': paint_logout})
 
 
 def attrs(request):

--- a/demo-django/demo/wsgi.py
+++ b/demo-django/demo/wsgi.py
@@ -10,5 +10,5 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo.settings")
 
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # noqa: E402
 application = get_wsgi_application()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
+[flake8]
+ignore = E731,W504
+max-complexity = 48
+max-line-length = 1900
+
 [wheel]
 python-tag = py27

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,11 @@ setup(
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
     extras_require={
         'test': (
-            'coverage>=3.6',
-            'freezegun==0.3.5',
-            'pylint==1.9.1',
-            'pep8==1.5.7',
-            'pyflakes==0.8.1',
-            'coveralls==1.1',
+            'coverage>=4.5.2',
+            'freezegun==0.3.11',
+            'pylint==1.9.4',
+            'flake8==3.6.0',
+            'coveralls==1.5.1',
         ),
     },
     keywords='saml saml2 xmlsec django flask pyramid python3',

--- a/src/onelogin/saml2/idp_metadata_parser.py
+++ b/src/onelogin/saml2/idp_metadata_parser.py
@@ -55,7 +55,7 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                 idp_descriptor_nodes = OneLogin_Saml2_XML.query(dom, '//md:IDPSSODescriptor')
                 if idp_descriptor_nodes:
                     valid = True
-            except:
+            except Exception:
                 pass
 
         if not valid:

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -391,7 +391,7 @@ class OneLogin_Saml2_Utils(object):
 
     @staticmethod
     def parse_time_to_SAML(time):
-        """
+        r"""
         Converts a UNIX timestamp to SAML2 timestamp on the form
         yyyy-mm-ddThh:mm:ss(\.s+)?Z.
 
@@ -406,7 +406,7 @@ class OneLogin_Saml2_Utils(object):
 
     @staticmethod
     def parse_SAML_to_time(timestr):
-        """
+        r"""
         Converts a SAML2 timestamp on the form yyyy-mm-ddThh:mm:ss(\.s+)?Z
         to a UNIX timestamp. The sub-second part is ignored.
 

--- a/tests/pep8.rc
+++ b/tests/pep8.rc
@@ -1,3 +1,0 @@
-[pep8]
-ignore = E501,E731
-max-line-length = 160

--- a/tests/src/OneLogin/saml2_tests/authn_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/authn_request_test.py
@@ -267,7 +267,7 @@ class OneLogin_Saml2_Authn_Request_Test(unittest.TestCase):
             'SAMLRequest': authn_request.get_request()
         }
         auth_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SSOService.php', parameters, True)
-        self.assertRegex(auth_url, '^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=')
+        self.assertRegex(auth_url, r'^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=')
         exploded = urlparse(auth_url)
         exploded = parse_qs(exploded[4])
         payload = exploded['SAMLRequest'][0]
@@ -295,7 +295,7 @@ class OneLogin_Saml2_Authn_Request_Test(unittest.TestCase):
             'SAMLRequest': authn_request.get_request()
         }
         auth_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SSOService.php', parameters, True)
-        self.assertRegex(auth_url, '^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=')
+        self.assertRegex(auth_url, r'^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=')
         exploded = urlparse(auth_url)
         exploded = parse_qs(exploded[4])
         payload = exploded['SAMLRequest'][0]

--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -5,7 +5,7 @@
 
 try:
     from urllib.error import URLError
-except:
+except ImportError:
     from urllib2 import URLError
 
 from copy import deepcopy

--- a/tests/src/OneLogin/saml2_tests/logout_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_request_test.py
@@ -65,7 +65,7 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
 
         parameters = {'SAMLRequest': logout_request.get_request()}
         logout_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SingleLogoutService.php', parameters, True)
-        self.assertRegex(logout_url, '^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
+        self.assertRegex(logout_url, r'^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
         url_parts = urlparse(logout_url)
         exploded = parse_qs(url_parts.query)
         payload = exploded['SAMLRequest'][0]
@@ -82,7 +82,7 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
 
         parameters = {'SAMLRequest': logout_request.get_request()}
         logout_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SingleLogoutService.php', parameters, True)
-        self.assertRegex(logout_url, '^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
+        self.assertRegex(logout_url, r'^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
         url_parts = urlparse(logout_url)
         exploded = parse_qs(url_parts.query)
         payload = exploded['SAMLRequest'][0]
@@ -139,7 +139,7 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
 
         parameters = {'SAMLRequest': logout_request.get_request()}
         logout_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SingleLogoutService.php', parameters, True)
-        self.assertRegex(logout_url, '^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
+        self.assertRegex(logout_url, r'^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=')
         url_parts = urlparse(logout_url)
         exploded = parse_qs(url_parts.query)
         payload = exploded['SAMLRequest'][0]

--- a/tests/src/OneLogin/saml2_tests/logout_response_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_response_test.py
@@ -77,7 +77,7 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
 
         logout_url = OneLogin_Saml2_Utils.redirect('http://idp.example.com/SingleLogoutService.php', parameters, True)
 
-        self.assertRegex(logout_url, '^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLResponse=')
+        self.assertRegex(logout_url, r'^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLResponse=')
         url_parts = urlparse(logout_url)
         exploded = parse_qs(url_parts.query)
         inflated = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(exploded['SAMLResponse'][0]))


### PR DESCRIPTION
Applying the lessons learned from onelogin/python-saml#246

Add Python 3.7 to the testing.

Add [flake8](http://flake8.pycqa.org) which is a superset of __pycodestyle__ (fka pep8) plus __pyflakes__ plus McCabe complexity analysis.  This PR runs all the same tests as the current pep8 and pyflakes plus it adds several new tests.  The numbers in __setup.cfg__ for __max-complexity__ and __max-line-length__ are really too high and should be something like __10__ and __127__ respectively.