### PR TITLE
setup.py: Add the Python 3.7 trove classifier for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     author='OneLogin',
     author_email='support@onelogin.com',


### PR DESCRIPTION
Now that #124 is merged and Python 3.7 is passing the Travis tests.