### PR TITLE
Make tests pass in 2020

### DIFF
--- a/tests/data/metadata/metadata_settings1.xml
+++ b/tests/data/metadata/metadata_settings1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
-                     validUntil="2020-03-05T18:19:11Z"
+                     validUntil="2037-03-05T18:19:11Z"
                      cacheDuration="PT1594475551S"
                      entityID="http://stuff.com/endpoints/metadata.php">
     <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">


### PR DESCRIPTION
Make tests pass in 2020

moving this date beyond 2038 requires fixes on 32-bit systems to avoid errors:

```
   File "/home/abuild/rpmbuild/BUILD/python3-saml-1.6.0/tests/src/OneLogin/saml2_tests/settings_test.py", line 560, in testValidateMetadata
     self.assertEqual(len(settings.validate_metadata(xml)), 0)
   File "/home/abuild/rpmbuild/BUILD/python3-saml-1.6.0/src/onelogin/saml2/settings.py", line 716, in validate_metadata
     expire_time = OneLogin_Saml2_Utils.get_expire_time(cache_duration, valid_until)
   File "/home/abuild/rpmbuild/BUILD/python3-saml-1.6.0/src/onelogin/saml2/utils.py", line 480, in get_expire_time
     valid_until_time = OneLogin_Saml2_Utils.parse_SAML_to_time(valid_until)
   File "/home/abuild/rpmbuild/BUILD/python3-saml-1.6.0/src/onelogin/saml2/utils.py", line 419, in parse_SAML_to_time
     data = datetime.strptime(timestr, '%Y-%m-%dT%H:%M:%SZ')
 TypeError: strptime() argument 1 must be string, not long
```

Background:
As part of my work on reproducible builds for openSUSE,
I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some
software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.