### PR TITLE
Added get_in_response_to method to Response and LogoutResponse classes

### DIFF
--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -176,6 +176,11 @@ class OneLogin_Saml2_Logout_Response(object):
         self.__logout_response = logout_response
 
     def get_in_response_to(self):
+        """
+        Gets the ID of the LogoutRequest which this response is in response to
+        :returns: ID of LogoutRequest this LogoutResponse is in response to or None if it is not present
+        :rtype: str
+        """
         return self.document.get('InResponseTo')
 
     def get_response(self, deflate=True):

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -95,7 +95,7 @@ class OneLogin_Saml2_Logout_Response(object):
                 security = self.__settings.get_security_data()
 
                 # Check if the InResponseTo of the Logout Response matches the ID of the Logout Request (requestId) if provided
-                in_response_to = self.document.get('InResponseTo', None)
+                in_response_to = self.get_in_response_to()
                 if request_id is not None and in_response_to and in_response_to != request_id:
                     raise OneLogin_Saml2_ValidationError(
                         'The InResponseTo of the Logout Response: %s, does not match the ID of the Logout request sent by the SP: %s' % (in_response_to, request_id),
@@ -174,6 +174,9 @@ class OneLogin_Saml2_Logout_Response(object):
             }
 
         self.__logout_response = logout_response
+
+    def get_in_response_to(self):
+        return self.document.get('InResponseTo')
 
     def get_response(self, deflate=True):
         """

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -122,7 +122,7 @@ class OneLogin_Saml2_Response(object):
                 current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)
 
                 # Check if the InResponseTo of the Response matchs the ID of the AuthNRequest (requestId) if provided
-                in_response_to = self.document.get('InResponseTo', None)
+                in_response_to = self.get_in_response_to()
                 if in_response_to is not None and request_id is not None:
                     if in_response_to != request_id:
                         raise OneLogin_Saml2_ValidationError(
@@ -386,6 +386,14 @@ class OneLogin_Saml2_Response(object):
         """
         authn_context_nodes = self.__query_assertion('/saml:AuthnStatement/saml:AuthnContext/saml:AuthnContextClassRef')
         return [OneLogin_Saml2_XML.element_text(node) for node in authn_context_nodes]
+
+    def get_in_response_to(self):
+        """
+        Gets the ID of the request which this response is in response to
+        :returns: ID of AuthNRequest this Response is in response to or None if it is not present
+        :rtype: str
+        """
+        return self.document.get('InResponseTo')
 
     def get_issuers(self):
         """

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -75,8 +75,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml = self.file_contents(join(self.data_path, 'responses', 'signed_message_response.xml.base64'))
         response = OneLogin_Saml2_Response(settings, xml)
-        prety_xml = self.file_contents(join(self.data_path, 'responses', 'pretty_signed_message_response.xml'))
-        self.assertEqual(etree.tostring(response.get_xml_document(), encoding='unicode', pretty_print=True), prety_xml)
+        pretty_xml = self.file_contents(join(self.data_path, 'responses', 'pretty_signed_message_response.xml'))
+        self.assertEqual(etree.tostring(response.get_xml_document(), encoding='unicode', pretty_print=True), pretty_xml)
 
         xml_2 = self.file_contents(join(self.data_path, 'responses', 'valid_encrypted_assertion.xml.base64'))
         response_2 = OneLogin_Saml2_Response(settings, xml_2)

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -407,7 +407,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(json_settings)
         response_13 = OneLogin_Saml2_Response(settings, xml_6)
         nameid_data_13 = response_13.get_nameid_data()
-        nameid_data_13 = self.assertEqual(expected_nameid_data_5, nameid_data_13)
+        self.assertEqual(expected_nameid_data_5, nameid_data_13)
 
         json_settings['strict'] = False
         json_settings['security']['wantNameId'] = False
@@ -684,6 +684,22 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         xml_3 = self.file_contents(join(self.data_path, 'responses', 'valid_encrypted_assertion.xml.base64'))
         response_3 = OneLogin_Saml2_Response(settings, xml_3)
         self.assertEqual(2696012228, response_3.get_session_not_on_or_after())
+
+    def testGetInResponseTo(self):
+        """
+        Tests the retrieval of the InResponseTo attribute
+        """
+
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+
+        # Response without an InResponseTo element should return None
+        xml = self.file_contents(join(self.data_path, 'responses', 'response1.xml.base64'))
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertIsNone(response.get_in_response_to())
+
+        xml_3 = self.file_contents(join(self.data_path, 'responses', 'valid_encrypted_assertion.xml.base64'))
+        response_3 = OneLogin_Saml2_Response(settings, xml_3)
+        self.assertEqual('ONELOGIN_be60b8caf8e9d19b7a3551b244f116c947ff247d', response_3.get_in_response_to())
 
     def testIsInvalidXML(self):
         """


### PR DESCRIPTION
Easier access for SP use to prevent replay attacks and match Responses to Requests