### PR TITLE
return_false_on_exception: only catch OneLogin SAML specific exceptions

### DIFF
--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -47,7 +47,7 @@ def return_false_on_exception(func):
         if not kwargs.pop('raise_exceptions', False):
             try:
                 return func(*args, **kwargs)
-            except Exception:
+            except (OneLogin_Saml2_Error, OneLogin_Saml2_ValidationError):
                 return False
         else:
             return func(*args, **kwargs)


### PR DESCRIPTION
Instead of hiding any exception, hide OneLogin SAML specific exceptions so that any other errors (for example, xmlsec is unable to load the certificate) are passed through. It's often better to pass these through and possibly cause internal server error to be displayed. Alternatively, user (and administrator) would see confusing, unrelated error message which makes finding the root cause very difficult.