### PR TITLE
Drop python3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # python3-saml changelog
+### 1.7.1 (unrelease)
+* Drop python3.4 support
+
 ### 1.7.0 (Jul 02, 2019)
 * Adjusted acs endpoint to extract NameQualifier and SPNameQualifier from SAMLResponse. Adjusted single logout service to provide NameQualifier and SPNameQualifier to logout method. Add getNameIdNameQualifier to Auth and SamlResponse. Extend logout method from Auth and LogoutRequest constructor to support SPNameQualifier parameter. Align LogoutRequest constructor with SAML specs
 * Added get_in_response_to method to Response and LogoutResponse classes


### PR DESCRIPTION
Python3.4 is not supported anymore by lxml. Since lots of distribution handle python3.5 by default and because it breaks the CI, it looks obvious to drop it.