### PR TITLE
Fix get_attribute() returning an empty list

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -319,7 +319,7 @@ class OneLogin_Saml2_Auth(object):
         :rtype: string
         """
         assert isinstance(name, compat.str_type)
-        return self.__attributes.get(name)
+        return self.__attributes.get(name, [])
 
     def get_last_request_id(self):
         """


### PR DESCRIPTION
The docstring for `get_attribute` says `:returns: Attribute value if exists or []`. Currently, `get_attribute` returns None if the attribute doesn't exist