### PR TITLE
Find X509Certificate nodes regardless of namepsace

### DIFF
--- a/src/onelogin/saml2/idp_metadata_parser.py
+++ b/src/onelogin/saml2/idp_metadata_parser.py
@@ -162,8 +162,16 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                 if len(slo_nodes) > 0:
                     idp_slo_url = slo_nodes[0].get('Location', None)
 
-                signing_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'encryption'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
-                encryption_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'signing'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
+                signing_nodes = OneLogin_Saml2_XML.query(
+                    idp_descriptor_node,
+                    "./md:KeyDescriptor[not(contains(@use, 'encryption'))]"
+                    "/*[local-name() = 'KeyInfo']/*[local-name() = 'X509Data']/*[local-name() = 'X509Certificate']"
+                )
+                encryption_nodes = OneLogin_Saml2_XML.query(
+                    idp_descriptor_node,
+                    "./md:KeyDescriptor[not(contains(@use, 'signing'))]"
+                    "/*[local-name() = 'KeyInfo']/*[local-name() = 'X509Data']/*[local-name() = 'X509Certificate']"
+                )
 
                 if len(signing_nodes) > 0 or len(encryption_nodes) > 0:
                     certs = {}


### PR DESCRIPTION
A number of IdPs do not issue metadata with namepsaced KeyInfo nodes.
This change attempts to support those IdPs metadata. 