### PR TITLE
allow user generated request id in the authn request

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,11 +614,12 @@ We can set a ``return_to`` url parameter to the login function and that will be 
 target_url = 'https://example.com'
 auth.login(return_to=target_url)
 ```
-The login method can recieve 3 more optional parameters:
+The login method can receive 3 more optional parameters:
 
-* ``force_authn``       When ``true``, the ``AuthNReuqest`` will set the ``ForceAuthn='true'``
-* ``is_passive``        When true, the ``AuthNReuqest`` will set the ``Ispassive='true'``
-* ``set_nameid_policy`` When true, the ``AuthNReuqest`` will set a ``nameIdPolicy`` element.
+* ``force_authn``       When ``true``, the ``AuthNRequest`` will set the ``ForceAuthn='true'``
+* ``is_passive``        When true, the ``AuthNRequest`` will set the ``Ispassive='true'``
+* ``set_nameid_policy`` When true, the ``AuthNRequest`` will set a ``nameIdPolicy`` element.
+* ``request_id``        When specified, the ``AuthNRequest`` will set a user provided ``ID`` attribute.
 
 If a match on the future ``SAMLResponse`` ID and the ``AuthNRequest`` ID to be sent is required, that ``AuthNRequest`` ID must to be extracted and stored for future validation, we can get that ID by
 

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -349,7 +349,7 @@ class OneLogin_Saml2_Auth(object):
         """
         return self.__last_authn_contexts
 
-    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None):
+    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, request_id=None):
         """
         Initiates the SSO process.
 
@@ -371,7 +371,7 @@ class OneLogin_Saml2_Auth(object):
         :returns: Redirection URL
         :rtype: string
         """
-        authn_request = OneLogin_Saml2_Authn_Request(self.__settings, force_authn, is_passive, set_nameid_policy, name_id_value_req)
+        authn_request = OneLogin_Saml2_Authn_Request(self.__settings, force_authn, is_passive, set_nameid_policy, name_id_value_req, request_id)
         self.__last_request = authn_request.get_xml()
         self.__last_request_id = authn_request.get_id()
 

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -22,7 +22,7 @@ class OneLogin_Saml2_Authn_Request(object):
 
     """
 
-    def __init__(self, settings, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None):
+    def __init__(self, settings, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, request_id=None):
         """
         Constructs the AuthnRequest object.
 
@@ -40,6 +40,9 @@ class OneLogin_Saml2_Authn_Request(object):
 
         :param name_id_value_req: Optional argument. Indicates to the IdP the subject that should be authenticated
         :type name_id_value_req: string
+
+        :param request_id: Optional argument. Allows a user specified request id in the Authn Request
+        :type request_id: string
         """
         self.__settings = settings
 
@@ -47,7 +50,12 @@ class OneLogin_Saml2_Authn_Request(object):
         idp_data = self.__settings.get_idp_data()
         security = self.__settings.get_security_data()
 
-        uid = OneLogin_Saml2_Utils.generate_unique_id()
+        if request_id is None:
+            uid = OneLogin_Saml2_Utils.generate_unique_id()
+
+        else:
+            uid = request_id
+
         self.__id = uid
         issue_instant = OneLogin_Saml2_Utils.parse_time_to_SAML(OneLogin_Saml2_Utils.now())
 


### PR DESCRIPTION
The saml2 toolkit generates a random request id for the Authn Request created at the SP for the IdP (Onelogin)

However, when integrating the saml toolkit with a SP that already has session management, it makes sense to reuse the SP session management instead of having the toolkit create new request id and the added over head of storing and validating a second request id. 

This feature will allow easier integration of the Onelogin saml toolkit between a SP and Onelogin as the IdP

This feature added a new parameter to the login API that allows the user to specify a request id to be used in the authn request. The API is backwards compatible so if the user does not specify a request_id, it defaults to None and the saml toolkits automatically generates one as it did before. Therefore this is no change in behavior of the API or toolkit.

In addition, since the login API utilizes the OneLogin_Saml2_Authn_Request that generates the request Id, the optional request_id parameter was also added to the  OneLogin_Saml2_Authn_Request API.