### PR TITLE
fix: treat single-label-domains as valid

### DIFF
--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -34,6 +34,7 @@ except NameError:
 url_regex = re.compile(
     r'^(?:[a-z0-9\.\-]*)://'  # scheme is validated separately
     r'(?:(?:[A-Z0-9_](?:[A-Z0-9-_]{0,61}[A-Z0-9_])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
+    r'(?:[A-Z0-9_](?:[A-Z0-9-_]{0,61}[A-Z0-9_]))|'  # single-label-domain
     r'localhost|'  # localhost...
     r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # ...or ipv4
     r'\[?[A-F0-9]*:[A-F0-9:]+\]?)'  # ...or ipv6

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -64,12 +64,9 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         except Exception as e:
             self.assertIn('Invalid dict settings: idp_sso_url_invalid', str(e))
 
-        settings_info['idp']['singleSignOnService']['url'] = 'http://invalid_domain'
-        try:
-            settings_3 = OneLogin_Saml2_Settings(settings_info)
-            self.assertNotEqual(len(settings_3.get_errors()), 0)
-        except Exception as e:
-            self.assertIn('Invalid dict settings: idp_sso_url_invalid', str(e))
+        settings_info['idp']['singleSignOnService']['url'] = 'http://single-label-domain'
+        settings_3 = OneLogin_Saml2_Settings(settings_info)
+        self.assertEqual(len(settings_3.get_errors()), 0)
 
         del settings_info['sp']
         del settings_info['idp']


### PR DESCRIPTION
Fixes https://github.com/onelogin/python3-saml/issues/108

In Docker/Kubernetes/testing, it's common to have a service/hostname
without a domain i.e. http://saml-service:5555. Some places refer to
these as single-label-domains[1]

Previously validate_url only allowed `localhost` and considered other
hostnames invalid if they didn't contain a domain suffix. This relaxes
the restriction to allow for single-label-domains

[1] https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/single-label-domains-support-policy