### PR TITLE
Enabling different slo endpoint for responses to IdP-initiated logout

### DIFF
--- a/docs/saml2/_modules/saml2/auth.html
+++ b/docs/saml2/_modules/saml2/auth.html
@@ -315,7 +315,7 @@
             <span class="n">parameters</span><span class="p">[</span><span class="s">&#39;Signature&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">build_request_signature</span><span class="p">(</span><span class="n">saml_request</span><span class="p">,</span> <span class="n">parameters</span><span class="p">[</span><span class="s">&#39;RelayState&#39;</span><span class="p">])</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">redirect_to</span><span class="p">(</span><span class="n">slo_url</span><span class="p">,</span> <span class="n">parameters</span><span class="p">)</span>
 </div>
-<div class="viewcode-block" id="OneLogin_Saml2_Auth.get_sso_url"><a class="viewcode-back" href="../../saml2.html#saml2.auth.OneLogin_Saml2_Auth.get_sso_url">[docs]</a>    <span class="k">def</span> <span class="nf">get_sso_url</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+<div class="viewcode-block" id="OneLogin_Saml2_Settings.get_sso_url"><a class="viewcode-back" href="../../saml2.html#saml2.settings.OneLogin_Saml2_Settings.get_sso_url">[docs]</a>    <span class="k">def</span> <span class="nf">get_sso_url</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Gets the SSO url.</span>
 

--- a/docs/saml2/genindex.html
+++ b/docs/saml2/genindex.html
@@ -436,7 +436,7 @@
   </dt>
 
       
-  <dt><a href="saml2.html#saml2.auth.OneLogin_Saml2_Auth.get_sso_url">get_sso_url() (saml2.auth.OneLogin_Saml2_Auth method)</a>
+  <dt><a href="saml2.html#saml2.settings.OneLogin_Saml2_Settings.get_sso_url">get_sso_url() (saml2.auth.OneLogin_Saml2_Auth method)</a>
   </dt>
 
       

--- a/docs/saml2/saml2.html
+++ b/docs/saml2/saml2.html
@@ -199,8 +199,8 @@
 </dd></dl>
 
 <dl class="method">
-<dt id="saml2.auth.OneLogin_Saml2_Auth.get_sso_url">
-<tt class="descname">get_sso_url</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/saml2/auth.html#OneLogin_Saml2_Auth.get_sso_url"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#saml2.auth.OneLogin_Saml2_Auth.get_sso_url" title="Permalink to this definition">¶</a></dt>
+<dt id="saml2.settings.OneLogin_Saml2_Settings.get_sso_url">
+<tt class="descname">get_sso_url</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/saml2/settings.html#OneLogin_Saml2_Settings.get_sso_url"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#saml2.settings.OneLogin_Saml2_Settings.get_sso_url" title="Permalink to this definition">¶</a></dt>
 <dd><p>Gets the SSO url.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -190,7 +190,7 @@ class OneLogin_Saml2_Auth(object):
                 if security['logoutResponseSigned']:
                     self.add_response_signature(parameters, security['signatureAlgorithm'])
 
-                return self.redirect_to(self.get_slo_response_url(), parameters)
+                return self.redirect_to(self.__settings.get_slo_response_url(), parameters)
         else:
             self.__errors.append('invalid_binding')
             raise OneLogin_Saml2_Error(
@@ -386,7 +386,7 @@ class OneLogin_Saml2_Auth(object):
         security = self.__settings.get_security_data()
         if security.get('authnRequestsSigned', False):
             self.add_request_signature(parameters, security['signatureAlgorithm'])
-        return self.redirect_to(self.get_sso_url(), parameters)
+        return self.redirect_to(self.__settings.get_sso_url(), parameters)
 
     def logout(self, return_to=None, name_id=None, session_index=None, nq=None, name_id_format=None, spnq=None):
         """
@@ -412,7 +412,7 @@ class OneLogin_Saml2_Auth(object):
 
         :returns: Redirection URL
         """
-        slo_url = self.get_slo_url()
+        slo_url = self.__settings.get_slo_url()
         if slo_url is None:
             raise OneLogin_Saml2_Error(
                 'The IdP does not support Single Log Out',
@@ -446,37 +446,6 @@ class OneLogin_Saml2_Auth(object):
         if security.get('logoutRequestSigned', False):
             self.add_request_signature(parameters, security['signatureAlgorithm'])
         return self.redirect_to(slo_url, parameters)
-
-    def get_sso_url(self):
-        """
-        Gets the SSO URL.
-
-        :returns: An URL, the SSO endpoint of the IdP
-        :rtype: string
-        """
-        idp_data = self.__settings.get_idp_data()
-        return idp_data['singleSignOnService']['url']
-
-    def get_slo_url(self):
-        """
-        Gets the SLO URL.
-
-        :returns: An URL, the SLO endpoint of the IdP
-        :rtype: string
-        """
-        idp_data = self.__settings.get_idp_data()
-        if 'url' in idp_data['singleLogoutService']:
-            return idp_data['singleLogoutService']['url']
-
-    def get_slo_response_url(self):
-        """
-        Gets the SLO return URL for IdP-initiated logout.
-
-        :returns: an URL, the SLO return endpoint of the IdP
-        :rtype: string
-        """
-        slo_data = self.__settings.get_idp_data()['singleLogoutService']
-        return slo_data.get('responseUrl', self.get_slo_url())
 
     def add_request_signature(self, request_data, sign_algorithm=OneLogin_Saml2_Constants.RSA_SHA1):
         """

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -162,7 +162,7 @@ class OneLogin_Saml2_Logout_Response(object):
 
         uid = OneLogin_Saml2_Utils.generate_unique_id()
         issue_instant = OneLogin_Saml2_Utils.parse_time_to_SAML(OneLogin_Saml2_Utils.now())
-        destination = idp_data['singleLogoutService'].get('responseUrl', idp_data['singleLogoutService']['url'])
+        destination = self.__settings.get_slo_response_url()
 
         logout_response = OneLogin_Saml2_Templates.LOGOUT_RESPONSE % \
             {

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -506,6 +506,37 @@ class OneLogin_Saml2_Settings(object):
         cert = self.get_sp_cert()
         return key is not None and cert is not None
 
+    def get_slo_url(self):
+        """
+        Gets the SLO URL.
+
+        :returns: An URL, the SLO endpoint of the IdP
+        :rtype: string
+        """
+        idp_data = self.get_idp_data()
+        if 'url' in idp_data['singleLogoutService']:
+            return idp_data['singleLogoutService']['url']
+
+    def get_slo_response_url(self):
+        """
+        Gets the SLO return URL for IdP-initiated logout.
+
+        :returns: an URL, the SLO return endpoint of the IdP
+        :rtype: string
+        """
+        slo_data = self.get_idp_data()['singleLogoutService']
+        return slo_data.get('responseUrl', self.get_slo_url())
+
+    def get_sso_url(self):
+        """
+        Gets the SSO URL.
+
+        :returns: An URL, the SSO endpoint of the IdP
+        :rtype: string
+        """
+        idp_data = self.get_idp_data()
+        return idp_data['singleSignOnService']['url']
+
     def get_sp_key(self):
         """
         Returns the x509 private key of the SP.

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -67,42 +67,6 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         auth_settings = auth.get_settings()
         self.assertEqual(settings.get_sp_data(), auth_settings.get_sp_data())
 
-    def testGetSSOurl(self):
-        """
-        Tests the get_sso_url method of the OneLogin_Saml2_Auth class
-        """
-        settings_info = self.loadSettingsJSON()
-        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
-
-        sso_url = settings_info['idp']['singleSignOnService']['url']
-        self.assertEqual(auth.get_sso_url(), sso_url)
-
-    def testGetSLOurl(self):
-        """
-        Tests the get_slo_url method of the OneLogin_Saml2_Auth class
-        """
-        settings_info = self.loadSettingsJSON()
-        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
-
-        slo_url = settings_info['idp']['singleLogoutService']['url']
-        self.assertEqual(auth.get_slo_url(), slo_url)
-
-    def testGetSLOresponseUrl(self):
-        """
-        Tests the get_slo_response_url method of the OneLogin_Saml2_Auth class
-        """
-        settings_info = self.loadSettingsJSON()
-        settings_info['idp']['singleLogoutService']['responseUrl'] = "http://idp.example.com/SingleLogoutReturn.php"
-        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
-        slo_url = settings_info['idp']['singleLogoutService']['responseUrl']
-        self.assertEqual(auth.get_slo_response_url(), slo_url)
-        # test that the function falls back to the url setting if responseUrl is not set
-        settings_info['idp']['singleLogoutService'].pop('responseUrl')
-        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
-        slo_url = settings_info['idp']['singleLogoutService']['url']
-        self.assertEqual(auth.get_slo_response_url(), slo_url)
-
-
     def testGetSessionIndex(self):
         """
         Tests the get_session_index method of the OneLogin_Saml2_Auth class

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -165,6 +165,41 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         base = settings.get_base_path()
         self.assertEqual(join(base, 'lib', 'schemas') + sep, settings.get_schemas_path())
 
+    def testGetSLOresponseUrl(self):
+        """
+        Tests the get_slo_response_url method of the OneLogin_Saml2_Auth class
+        """
+        settings_info = self.loadSettingsJSON()
+        settings_info['idp']['singleLogoutService']['responseUrl'] = "http://idp.example.com/SingleLogoutReturn.php"
+        settings = OneLogin_Saml2_Settings(settings_info)
+        slo_url = settings_info['idp']['singleLogoutService']['responseUrl']
+        self.assertEqual(settings.get_slo_response_url(), slo_url)
+        # test that the function falls back to the url setting if responseUrl is not set
+        settings_info['idp']['singleLogoutService'].pop('responseUrl')
+        settings = OneLogin_Saml2_Settings(settings_info)
+        slo_url = settings_info['idp']['singleLogoutService']['url']
+        self.assertEqual(settings.get_slo_response_url(), slo_url)
+    
+    def testGetSLOurl(self):
+        """
+        Tests the get_slo_url method of the OneLogin_Saml2_Auth class
+        """
+        settings_info = self.loadSettingsJSON()
+        settings = OneLogin_Saml2_Settings(settings_info)
+
+        slo_url = settings_info['idp']['singleLogoutService']['url']
+        self.assertEqual(settings.get_slo_url(), slo_url)
+    
+    def testGetSSOurl(self):
+        """
+        Tests the get_sso_url method of the OneLogin_Saml2_Auth class
+        """
+        settings_info = self.loadSettingsJSON()
+        auth = OneLogin_Saml2_Settings(settings_info)
+
+        sso_url = settings_info['idp']['singleSignOnService']['url']
+        self.assertEqual(auth.get_sso_url(), sso_url)
+    
     def testGetSPCert(self):
         """
         Tests the get_sp_cert method of the OneLogin_Saml2_Settings


### PR DESCRIPTION
This PR addresses issue #13 , which was not yet correctly adressed by the library. Implemented the suggested fix. Additionally, the `OneLogin_Saml2_Logout_Response.build` method was modified (only called by the IdP-initiated logout case of `process_slo`) such that the `Destination` field of the response payload will be set from the `responseUrl` setting, if applicable.

Adjusted README and added two simple tests.