### PR TITLE
Optionally modify request based on X-Forwarded headers in demo_pyramid

### DIFF
--- a/demo_pyramid/demo_pyramid/views.py
+++ b/demo_pyramid/demo_pyramid/views.py
@@ -19,6 +19,8 @@ def prepare_pyramid_request(request):
 
     if 'X-Forwarded-Proto' in request.headers:
         request.scheme = request.headers['X-Forwarded-Proto']
+    if 'X-Forwarded-Port' in request.headers:
+        request.server_port = int(request.headers['X-Forwarded-Port'])
 
     return {
         'https': 'on' if request.scheme == 'https' else 'off',

--- a/demo_pyramid/demo_pyramid/views.py
+++ b/demo_pyramid/demo_pyramid/views.py
@@ -15,12 +15,13 @@ def init_saml_auth(req):
 
 
 def prepare_pyramid_request(request):
-    # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
-
-    if 'X-Forwarded-Proto' in request.headers:
-        request.scheme = request.headers['X-Forwarded-Proto']
-    if 'X-Forwarded-Port' in request.headers:
-        request.server_port = int(request.headers['X-Forwarded-Port'])
+    ## Uncomment this portion to set the request.scheme and request.server_port
+    ## based on the supplied `X-Forwarded` headers
+    #
+    # if 'X-Forwarded-Proto' in request.headers:
+    #    request.scheme = request.headers['X-Forwarded-Proto']
+    # if 'X-Forwarded-Port' in request.headers:
+    #    request.server_port = int(request.headers['X-Forwarded-Port'])
 
     return {
         'https': 'on' if request.scheme == 'https' else 'off',

--- a/demo_pyramid/demo_pyramid/views.py
+++ b/demo_pyramid/demo_pyramid/views.py
@@ -16,6 +16,10 @@ def init_saml_auth(req):
 
 def prepare_pyramid_request(request):
     # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
+
+    if 'X-Forwarded-Proto' in request.headers:
+        request.scheme = request.headers['X-Forwarded-Proto']
+
     return {
         'https': 'on' if request.scheme == 'https' else 'off',
         'http_host': request.host,

--- a/demo_pyramid/demo_pyramid/views.py
+++ b/demo_pyramid/demo_pyramid/views.py
@@ -16,7 +16,8 @@ def init_saml_auth(req):
 
 def prepare_pyramid_request(request):
     ## Uncomment this portion to set the request.scheme and request.server_port
-    ## based on the supplied `X-Forwarded` headers
+    ## based on the supplied `X-Forwarded` headers.
+    ## Useful for running behind reverse proxies or balancers.
     #
     # if 'X-Forwarded-Proto' in request.headers:
     #    request.scheme = request.headers['X-Forwarded-Proto']


### PR DESCRIPTION
This PR helps when running a reverse proxy in front of the pyramid demo by overriding `request.scheme` and `request.server_port` when the proper `X-Forwarded` headers are set.