### PR TITLE
Resolved issue 226 with testing: Destination URL Comparison is now case-insensitive for netloc

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -314,7 +314,7 @@ class OneLogin_Saml2_Logout_Request(object):
                 if root.get('Destination', None):
                     destination = root.get('Destination')
                     if destination != '':
-                        if current_url not in destination:
+                        if OneLogin_Saml2_Utils.normalize_url(current_url) not in OneLogin_Saml2_Utils.normalize_url(destination):
                             raise OneLogin_Saml2_ValidationError(
                                 'The LogoutRequest was received at '
                                 '%(currentURL)s instead of %(destination)s' %

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -118,7 +118,7 @@ class OneLogin_Saml2_Logout_Response(object):
 
                 # Check destination
                 destination = self.document.get('Destination', None)
-                if destination and OneLogin_Saml2_Utils.normalize_url(current_url) not in OneLogin_Saml2_Utils.normalize_url(destination):
+                if destination and OneLogin_Saml2_Utils.normalize_url(url=current_url) not in OneLogin_Saml2_Utils.normalize_url(url=destination):
                     raise OneLogin_Saml2_ValidationError(
                         'The LogoutResponse was received at %s instead of %s' % (current_url, destination),
                         OneLogin_Saml2_ValidationError.WRONG_DESTINATION

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -118,7 +118,7 @@ class OneLogin_Saml2_Logout_Response(object):
 
                 # Check destination
                 destination = self.document.get('Destination', None)
-                if destination and current_url not in destination:
+                if destination and OneLogin_Saml2_Utils.normalize_url(current_url) not in OneLogin_Saml2_Utils.normalize_url(destination):
                     raise OneLogin_Saml2_ValidationError(
                         'The LogoutResponse was received at %s instead of %s' % (current_url, destination),
                         OneLogin_Saml2_ValidationError.WRONG_DESTINATION

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -10,6 +10,7 @@ SAML Response class of OneLogin's Python Toolkit.
 """
 
 from copy import deepcopy
+from urllib.parse import urlsplit, urlunsplit
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 from onelogin.saml2.utils import OneLogin_Saml2_Utils, OneLogin_Saml2_Error, OneLogin_Saml2_ValidationError, return_false_on_exception
 from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
@@ -191,7 +192,7 @@ class OneLogin_Saml2_Response(object):
                 # Checks destination
                 destination = self.document.get('Destination', None)
                 if destination:
-                    if not destination.startswith(current_url):
+                    if not self.__standardize_url(destination).startswith(self.__standardize_url(current_url)):
                         # TODO: Review if following lines are required, since we can control the
                         # request_data
                         #  current_url_routed = OneLogin_Saml2_Utils.get_self_routed_url_no_query(request_data)
@@ -865,6 +866,15 @@ class OneLogin_Saml2_Response(object):
                 decrypted = OneLogin_Saml2_Utils.decrypt_element(encrypted_data, key, debug=debug, inplace=True)
                 xml.replace(encrypted_assertion_nodes[0], decrypted)
         return xml
+            
+    def __standardize_url(self, url):
+        try:
+            parsed = list(urlsplit(url))
+            parsed[1] = parsed[1].lower()
+            standardized_url = urlunsplit(parsed)
+            return standardized_url
+        except Exception:
+            return url
 
     def get_error(self):
         """

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -881,11 +881,8 @@ class OneLogin_Saml2_Response(object):
         :rtype: list
         """
         try:
-            parsed = list(urlsplit(url))
-            #scheme and hostname converted to lowercase
-            parsed[0] = parsed[0].lower()
-            parsed[1] = parsed[1].lower()
-            normalized_url = urlunsplit(parsed)
+            scheme, netloc, *rest = urlsplit(url)
+            normalized_url = urlunsplit((scheme.lower(), netloc.lower(), *rest))
             return normalized_url
         except Exception:
             return url

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -192,7 +192,7 @@ class OneLogin_Saml2_Response(object):
                 # Checks destination
                 destination = self.document.get('Destination', None)
                 if destination:
-                    if not self.__normalize_url(destination).startswith(self.__normalize_url(current_url)):
+                    if not OneLogin_Saml2_Utils.normalize_url(destination).startswith(OneLogin_Saml2_Utils.normalize_url(current_url)):
                         # TODO: Review if following lines are required, since we can control the
                         # request_data
                         #  current_url_routed = OneLogin_Saml2_Utils.get_self_routed_url_no_query(request_data)
@@ -867,26 +867,6 @@ class OneLogin_Saml2_Response(object):
                 xml.replace(encrypted_assertion_nodes[0], decrypted)
         return xml
             
-    def __normalize_url(self, url):
-        """
-        Returns normalized URL for comparison. 
-        This method converts the netloc to lowercase, as it should be case-insensitive (per RFC 4343, RFC 7617)
-        If standardization fails, the original URL is returned
-        Python documentation indicates that URL split also normalizes query strings if empty query fields are present
-
-        :param url: URL
-        :type url: String
-
-        :returns: A normalized URL, or the given URL string if parsing fails
-        :rtype: list
-        """
-        try:
-            scheme, netloc, *rest = urlsplit(url)
-            normalized_url = urlunsplit((scheme.lower(), netloc.lower(), *rest))
-            return normalized_url
-        except Exception:
-            return url
-
     def get_error(self):
         """
         After executing a validation process, if it fails this method returns the cause

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -870,7 +870,7 @@ class OneLogin_Saml2_Response(object):
     def __normalize_url(self, url):
         """
         Returns normalized URL for comparison. 
-        This method converts the hostname to lowercase, as it should be case-insensitive (per RFC 4343)
+        This method converts the netloc to lowercase, as it should be case-insensitive (per RFC 4343, RFC 7617)
         If standardization fails, the original URL is returned
         Python documentation indicates that URL split also normalizes query strings if empty query fields are present
 
@@ -882,6 +882,8 @@ class OneLogin_Saml2_Response(object):
         """
         try:
             parsed = list(urlsplit(url))
+            #scheme and hostname converted to lowercase
+            parsed[0] = parsed[0].lower()
             parsed[1] = parsed[1].lower()
             normalized_url = urlunsplit(parsed)
             return normalized_url

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -192,7 +192,7 @@ class OneLogin_Saml2_Response(object):
                 # Checks destination
                 destination = self.document.get('Destination', None)
                 if destination:
-                    if not self.__standardize_url(destination).startswith(self.__standardize_url(current_url)):
+                    if not self.__normalize_url(destination).startswith(self.__normalize_url(current_url)):
                         # TODO: Review if following lines are required, since we can control the
                         # request_data
                         #  current_url_routed = OneLogin_Saml2_Utils.get_self_routed_url_no_query(request_data)
@@ -867,12 +867,24 @@ class OneLogin_Saml2_Response(object):
                 xml.replace(encrypted_assertion_nodes[0], decrypted)
         return xml
             
-    def __standardize_url(self, url):
+    def __normalize_url(self, url):
+        """
+        Returns normalized URL for comparison. 
+        This method converts the hostname to lowercase, as it should be case-insensitive (per RFC 4343)
+        If standardization fails, the original URL is returned
+        Python documentation indicates that URL split also normalizes query strings if empty query fields are present
+
+        :param url: URL
+        :type url: String
+
+        :returns: A normalized URL, or the given URL string if parsing fails
+        :rtype: list
+        """
         try:
             parsed = list(urlsplit(url))
             parsed[1] = parsed[1].lower()
-            standardized_url = urlunsplit(parsed)
-            return standardized_url
+            normalized_url = urlunsplit(parsed)
+            return normalized_url
         except Exception:
             return url
 

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -192,7 +192,7 @@ class OneLogin_Saml2_Response(object):
                 # Checks destination
                 destination = self.document.get('Destination', None)
                 if destination:
-                    if not OneLogin_Saml2_Utils.normalize_url(destination).startswith(OneLogin_Saml2_Utils.normalize_url(current_url)):
+                    if not OneLogin_Saml2_Utils.normalize_url(url=destination).startswith(OneLogin_Saml2_Utils.normalize_url(url=current_url)):
                         # TODO: Review if following lines are required, since we can control the
                         # request_data
                         #  current_url_routed = OneLogin_Saml2_Utils.get_self_routed_url_no_query(request_data)

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1062,3 +1062,24 @@ class OneLogin_Saml2_Utils(object):
             if debug:
                 print(e)
             return False
+
+        @staticmethod
+        def normalize_url(self, url):
+        """
+        Returns normalized URL for comparison. 
+        This method converts the netloc to lowercase, as it should be case-insensitive (per RFC 4343, RFC 7617)
+        If standardization fails, the original URL is returned
+        Python documentation indicates that URL split also normalizes query strings if empty query fields are present
+
+        :param url: URL
+        :type url: String
+
+        :returns: A normalized URL, or the given URL string if parsing fails
+        :rtype: String
+        """
+        try:
+            scheme, netloc, *rest = urlsplit(url)
+            normalized_url = urlunsplit((scheme.lower(), netloc.lower(), *rest))
+            return normalized_url
+        except Exception:
+            return url

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -20,7 +20,7 @@ from textwrap import wrap
 from functools import wraps
 from uuid import uuid4
 from xml.dom.minidom import Element
-
+from urllib.parse import urlsplit, urlunsplit
 import zlib
 import xmlsec
 
@@ -1063,8 +1063,8 @@ class OneLogin_Saml2_Utils(object):
                 print(e)
             return False
 
-        @staticmethod
-        def normalize_url(self, url):
+    @staticmethod
+    def normalize_url(url):
         """
         Returns normalized URL for comparison. 
         This method converts the netloc to lowercase, as it should be case-insensitive (per RFC 4343, RFC 7617)

--- a/tests/src/OneLogin/saml2_tests/logout_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_request_test.py
@@ -413,6 +413,70 @@ class OneLogin_Saml2_Logout_Request_Test(unittest.TestCase):
         logout_request5 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
         self.assertTrue(logout_request5.is_valid(request_data))
 
+    def testIsValidWithCapitalization(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_LogoutRequest
+        """
+        request_data = {
+            'http_host': 'exaMPLe.com',
+            'script_name': 'index.html'
+        }
+        request = self.file_contents(join(self.data_path, 'logout_requests', 'logout_request.xml'))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+
+        logout_request = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertTrue(logout_request.is_valid(request_data))
+
+        settings.set_strict(True)
+        logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertFalse(logout_request2.is_valid(request_data))
+
+        settings.set_strict(False)
+        dom = parseString(request)
+        logout_request3 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(dom.toxml()))
+        self.assertTrue(logout_request3.is_valid(request_data))
+
+        settings.set_strict(True)
+        logout_request4 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(dom.toxml()))
+        self.assertFalse(logout_request4.is_valid(request_data))
+
+        current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)
+        request = request.replace('http://stuff.com/endpoints/endpoints/sls.php', current_url.lower())
+        logout_request5 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertTrue(logout_request5.is_valid(request_data))
+
+    def testIsInValidWithCapitalization(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_LogoutRequest
+        """
+        request_data = {
+            'http_host': 'example.com',
+            'script_name': 'INdex.html'
+        }
+        request = self.file_contents(join(self.data_path, 'logout_requests', 'logout_request.xml'))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+
+        logout_request = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertTrue(logout_request.is_valid(request_data))
+
+        settings.set_strict(True)
+        logout_request2 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertFalse(logout_request2.is_valid(request_data))
+
+        settings.set_strict(False)
+        dom = parseString(request)
+        logout_request3 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(dom.toxml()))
+        self.assertTrue(logout_request3.is_valid(request_data))
+
+        settings.set_strict(True)
+        logout_request4 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(dom.toxml()))
+        self.assertFalse(logout_request4.is_valid(request_data))
+
+        current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)
+        request = request.replace('http://stuff.com/endpoints/endpoints/sls.php', current_url.lower())
+        logout_request5 = OneLogin_Saml2_Logout_Request(settings, OneLogin_Saml2_Utils.b64encode(request))
+        self.assertFalse(logout_request5.is_valid(request_data))
+
     def testIsValidWithXMLEncoding(self):
         """
         Tests the is_valid method of the OneLogin_Saml2_LogoutRequest

--- a/tests/src/OneLogin/saml2_tests/logout_response_test.py
+++ b/tests/src/OneLogin/saml2_tests/logout_response_test.py
@@ -276,6 +276,64 @@ class OneLogin_Saml2_Logout_Response_Test(unittest.TestCase):
         response_3 = OneLogin_Saml2_Logout_Response(settings, message_3)
         self.assertTrue(response_3.is_valid(request_data))
 
+    def testIsValidWithCapitalization(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_LogoutResponse
+        """
+        request_data = {
+            'http_host': 'exaMPLe.com',
+            'script_name': 'index.html',
+            'get_data': {}
+        }
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        message = self.file_contents(join(self.data_path, 'logout_responses', 'logout_response_deflated.xml.base64'))
+
+        response = OneLogin_Saml2_Logout_Response(settings, message)
+        self.assertTrue(response.is_valid(request_data))
+
+        settings.set_strict(True)
+        response_2 = OneLogin_Saml2_Logout_Response(settings, message)
+        with self.assertRaisesRegex(Exception, 'The LogoutResponse was received at'):
+            response_2.is_valid(request_data, raise_exceptions=True)
+
+        plain_message = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(message))
+        
+        current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data).lower()
+        plain_message = plain_message.replace('http://stuff.com/endpoints/endpoints/sls.php', current_url)
+        message_3 = OneLogin_Saml2_Utils.deflate_and_base64_encode(plain_message)
+
+        response_3 = OneLogin_Saml2_Logout_Response(settings, message_3)
+        self.assertTrue(response_3.is_valid(request_data))
+
+    def testIsInValidWithCapitalization(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_LogoutResponse
+        """
+        request_data = {
+            'http_host': 'example.com',
+            'script_name': 'INdex.html',
+            'get_data': {}
+        }
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        message = self.file_contents(join(self.data_path, 'logout_responses', 'logout_response_deflated.xml.base64'))
+
+        response = OneLogin_Saml2_Logout_Response(settings, message)
+        self.assertTrue(response.is_valid(request_data))
+
+        settings.set_strict(True)
+        response_2 = OneLogin_Saml2_Logout_Response(settings, message)
+        with self.assertRaisesRegex(Exception, 'The LogoutResponse was received at'):
+            response_2.is_valid(request_data, raise_exceptions=True)
+
+        plain_message = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(message))
+        current_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data).lower()
+        plain_message = plain_message.replace('http://stuff.com/endpoints/endpoints/sls.php', current_url)
+        message_3 = OneLogin_Saml2_Utils.deflate_and_base64_encode(plain_message)
+
+        response_3 = OneLogin_Saml2_Logout_Response(settings, message_3)
+        self.assertFalse(response_3.is_valid(request_data))
+
+
     def testIsValidWithXMLEncoding(self):
         """
         Tests the is_valid method of the OneLogin_Saml2_LogoutResponse

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1063,12 +1063,12 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         """
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         message = self.file_contents(join(self.data_path, 'responses', 'unsigned_response.xml.base64'))
-        
         #Test domain capitalized
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, message)
         self.assertFalse(response.is_valid(self.get_request_data_domain_capitalized()))
         self.assertNotIn('The response was received at', response.get_error())
+
         #Assert we got past the destination check, which appears later
         self.assertIn('A valid SubjectConfirmation was not found', response.get_error())
 

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1036,7 +1036,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         self.assertFalse(response_2.is_valid(self.get_request_data()))
         self.assertIn('The response was received at', response_2.get_error())
 
-    def testIsInValidCapitalizationOfDestinationElements(self):
+    def testIsInValidDestinationCapitalizationOfElements(self):
         """
         Tests the is_valid method of the OneLogin_Saml2_Response class
         Case Invalid Response due to differences in capitalization of path
@@ -1056,7 +1056,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         self.assertFalse(response_2.is_valid(self.get_request_data_both_capitalized()))
         self.assertIn('The response was received at', response_2.get_error())
 
-    def testIsValidCapitalizationOfDestinationHost(self):
+    def testIsValidDestinationCapitalizationOfHost(self):
         """
         Tests the is_valid method of the OneLogin_Saml2_Response class
         Case Valid Response, even if host is differently capitalized (per RFC)
@@ -1064,11 +1064,13 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         message = self.file_contents(join(self.data_path, 'responses', 'unsigned_response.xml.base64'))
         
-        #Test path capitalized
+        #Test domain capitalized
         settings.set_strict(True)
         response = OneLogin_Saml2_Response(settings, message)
         self.assertFalse(response.is_valid(self.get_request_data_domain_capitalized()))
         self.assertNotIn('The response was received at', response.get_error())
+        #Assert we got past the destination check, which appears later
+        self.assertIn('A valid SubjectConfirmation was not found', response.get_error())
 
     def testIsInValidAudience(self):
         """

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -18,7 +18,6 @@ from onelogin.saml2.response import OneLogin_Saml2_Response
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
-
 class OneLogin_Saml2_Response_Test(unittest.TestCase):
     data_path = join(dirname(dirname(dirname(dirname(__file__)))), 'data')
     settings_path = join(dirname(dirname(dirname(dirname(__file__)))), 'settings')
@@ -48,6 +47,24 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         return {
             'http_host': 'example.com',
             'script_name': 'index.html'
+        }
+
+    def get_request_data_domain_capitalized(self):
+        return {
+            'http_host': 'StuFF.Com',
+            'script_name': 'endpoints/endpoints/acs.php'
+        }
+    
+    def get_request_data_path_capitalized(self):
+        return {
+            'http_host': 'stuff.com',
+            'script_name': 'Endpoints/endPoints/acs.php'
+        }
+
+    def get_request_data_both_capitalized(self):
+        return {
+            'http_host': 'StuFF.Com',
+            'script_name': 'Endpoints/endPoints/aCs.php'
         }
 
     def testConstruct(self):
@@ -977,7 +994,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response = OneLogin_Saml2_Response(settings, xml)
         with self.assertRaisesRegex(Exception, 'Found an Attribute element with duplicated Name'):
             response.get_attributes()
-
+    
     def testIsInValidDestination(self):
         """
         Tests the is_valid method of the OneLogin_Saml2_Response class
@@ -1013,6 +1030,45 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response_5 = OneLogin_Saml2_Response(settings, message_4)
         self.assertFalse(response_5.is_valid(self.get_request_data()))
         self.assertIn('A valid SubjectConfirmation was not found on this Response', response_5.get_error())
+
+        settings.set_strict(True)
+        response_2 = OneLogin_Saml2_Response(settings, message)
+        self.assertFalse(response_2.is_valid(self.get_request_data()))
+        self.assertIn('The response was received at', response_2.get_error())
+
+    def testIsInValidCapitalizationOfDestinationElements(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_Response class
+        Case Invalid Response due to differences in capitalization of path
+        """
+
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        message = self.file_contents(join(self.data_path, 'responses', 'unsigned_response.xml.base64'))
+        
+        #Test path capitalized
+        settings.set_strict(True)
+        response = OneLogin_Saml2_Response(settings, message)
+        self.assertFalse(response.is_valid(self.get_request_data_path_capitalized()))
+        self.assertIn('The response was received at', response.get_error())
+
+        #Test both domain and path capitalized
+        response_2 = OneLogin_Saml2_Response(settings, message)
+        self.assertFalse(response_2.is_valid(self.get_request_data_both_capitalized()))
+        self.assertIn('The response was received at', response_2.get_error())
+
+    def testIsValidCapitalizationOfDestinationHost(self):
+        """
+        Tests the is_valid method of the OneLogin_Saml2_Response class
+        Case Valid Response, even if host is differently capitalized (per RFC)
+        """
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        message = self.file_contents(join(self.data_path, 'responses', 'unsigned_response.xml.base64'))
+        
+        #Test path capitalized
+        settings.set_strict(True)
+        response = OneLogin_Saml2_Response(settings, message)
+        self.assertFalse(response.is_valid(self.get_request_data_domain_capitalized()))
+        self.assertNotIn('The response was received at', response.get_error())
 
     def testIsInValidAudience(self):
         """

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -917,3 +917,15 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         # Signature Wrapping attack
         wrapping_attack1 = b64decode(self.file_contents(join(self.data_path, 'responses', 'invalids', 'signature_wrapping_attack.xml.base64')))
         self.assertFalse(OneLogin_Saml2_Utils.validate_sign(wrapping_attack1, cert))
+
+    def testNormalizeUrl(self):
+        base_url = 'https://blah.com/path'
+        capital_scheme = 'hTTps://blah.com/path'
+        capital_domain = 'https://blAH.Com/path'
+        capital_path = 'https://blah.com/PAth'
+        capital_all = 'HTTPS://BLAH.COM/PATH'
+
+        self.assertIn(base_url, OneLogin_Saml2_Utils.normalize_url(capital_scheme))
+        self.assertIn(base_url, OneLogin_Saml2_Utils.normalize_url(capital_domain))
+        self.assertNotIn(base_url, OneLogin_Saml2_Utils.normalize_url(capital_path))
+        self.assertNotIn(base_url, OneLogin_Saml2_Utils.normalize_url(capital_all))


### PR DESCRIPTION
PR to resolve: https://github.com/onelogin/python3-saml/issues/226. This PR resolves ignoring netloc case when comparing the Destination URL to the actual URL when validating SAML responses (per RFC 4343/7617)

Although a fix like this was suggested: https://github.com/onelogin/ruby-saml/blob/17fce0a6caa6282ebd51c6276d3a7b91138b8d24/lib/onelogin/ruby-saml/utils.rb#L284

The preferred change appears to be attempting to parse the both the expected and the actual url, converting the hostname to lowercase, and returning it as a string. This solution results in the fewest code changes. If the URL parsing fails, the original url is returned, so the backend behavior regresses to the current implementation.

I do wonder if we should be using:

```python
if not self.__standardize_url(destination).equals(self.__standardize_url(current_url))
```

instead of 
```python
if not self.__standardize_url(destination).startswith(self.__standardize_url(current_url))
```

The SAML Docs [https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf](url) define destination as:

"A URI reference indicating the address to which this request has been sent. This is useful to prevent malicious forwarding of requests to unintended recipients, a protection that is required by some protocol bindings. If it is present, the actual recipient MUST check that the URI reference identifies the location at which the message was received"

This seems to imply that they must be an exact match, as such .equals may be more appropriate here.
