### PR TITLE
Add 'forceEncryptionKeyInMetadata' SP security setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,11 @@ In addition to the required settings data (idp, sp), extra settings can be defin
 
         /** signatures and encryptions required **/
 
+        // Indicates a requirement of having the encryption key present in the
+        // metadata even if this SP does not explicitly require encrypted
+        // responses. This is to accomodate IdPs that require encryption.
+        "forceEncryptionKeyInMetadata": false,
+
         // Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest>
         // and <samlp:LogoutResponse> elements received by this SP to be signed.
         "wantMessagesSigned": false,

--- a/demo-django/saml/advanced_settings.json
+++ b/demo-django/saml/advanced_settings.json
@@ -5,6 +5,7 @@
         "logoutRequestSigned": false,
         "logoutResponseSigned": false,
         "signMetadata": false,
+        "forceEncryptionKeyInMetadata": false,
         "wantMessagesSigned": false,
         "wantAssertionsSigned": false,
         "wantNameId" : true,

--- a/demo-flask/saml/advanced_settings.json
+++ b/demo-flask/saml/advanced_settings.json
@@ -5,6 +5,7 @@
         "logoutRequestSigned": false,
         "logoutResponseSigned": false,
         "signMetadata": false,
+        "forceEncryptionKeyInMetadata": false,
         "wantMessagesSigned": false,
         "wantAssertionsSigned": false,
         "wantNameId" : true,

--- a/demo-tornado/saml/advanced_settings.json
+++ b/demo-tornado/saml/advanced_settings.json
@@ -5,6 +5,7 @@
         "logoutRequestSigned": false,
         "logoutResponseSigned": false,
         "signMetadata": false,
+        "forceEncryptionKeyInMetadata": false,
         "wantMessagesSigned": false,
         "wantAssertionsSigned": false,
         "wantNameId" : true,

--- a/demo_pyramid/demo_pyramid/saml/advanced_settings.json
+++ b/demo_pyramid/demo_pyramid/saml/advanced_settings.json
@@ -5,6 +5,7 @@
         "logoutRequestSigned": false,
         "logoutResponseSigned": false,
         "signMetadata": false,
+        "forceEncryptionKeyInMetadata": false,
         "wantMessagesSigned": false,
         "wantAssertionsSigned": false,
         "wantNameId" : true,

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -290,6 +290,7 @@ class OneLogin_Saml2_Settings(object):
         self.__security.setdefault('wantNameId', True)
 
         # Encrypt expected
+        self.__security.setdefault('forceEncryptionKeyInMetadata', False)
         self.__security.setdefault('wantAssertionsEncrypted', False)
         self.__security.setdefault('wantNameIdEncrypted', False)
 
@@ -624,7 +625,7 @@ class OneLogin_Saml2_Settings(object):
             self.get_contacts(), self.get_organization()
         )
 
-        add_encryption = self.__security['wantNameIdEncrypted'] or self.__security['wantAssertionsEncrypted']
+        add_encryption = self.__security['wantNameIdEncrypted'] or self.__security['wantAssertionsEncrypted'] or self.__security['forceEncryptionKeyInMetadata']
 
         cert_new = self.get_sp_cert_new()
         metadata = OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, cert_new, add_encryption)


### PR DESCRIPTION
Adds the option of forcing the encryption key to be present in the metadata file even if the SP does not require any response to be encrypted.

If the `wantAssertionsEncrypted` and `wantNameIdEncrypted` options are `false` in the security settings the encryption key is not included in the metadata. That makes sense. The SP does not require any encrypted elements on the response so there is no need to include it in the metadata file. However I have come across a case where the IdP **requires** these elements to be encrypted.
I need to support one such IdP while also supporting one that does not support encryption at all. By changing these values to `false` I assumed that "Whether or not to encrypt would be up to the IdP, if supported, and the SP can handle both cases" but since the encryption key is not sent, an error occurs. So to support this case this PR adds a security setting that forces the Encryption Key to be present in the metadata even when no encrypted element is _required_ to be in the response.

Another way of doing this would be to have a setting on the IdP settings block (where we also define the entityId, etc.) asserting whether it requires the encryption key. Then when creating the SP metadata, we could loop through them to verify if there was at least one IdP with this requirement.

Notes:
- I have edited all the files I could find with the encryption settings and added documentation in the README.
- I noticed you have tests for this package, but since I'm not familiar with how to make them, I have not created tests for the code added by this PR.
- Since this is my first contribution to this project I expect many things to not meet your standards. I'll try to follow your feedback in order to have this change merged into the codebase.

I suspect you will want a different name for this setting.