### PR TITLE
Remove the dependency on defusedxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Installation
  * [xmlsec](https://pypi.python.org/pypi/xmlsec) Python bindings for the XML Security Library.
  * [isodate](https://pypi.python.org/pypi/isodate) An ISO 8601 date/time/
  duration parser and formatter
- * [defusedxml](https://pypi.python.org/pypi/defusedxml) XML bomb protection for Python stdlib modules
 
 Review the ``setup.py`` file to know the version of the library that ``python3-saml`` is using
 

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ setup(
     install_requires=[
         'isodate>=0.5.0',
         'lxml>=3.3.5',
-        'xmlsec>=1.0.5',
-        'defusedxml==0.6.0'
+        'xmlsec>=1.0.5'
     ],
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
     extras_require={

--- a/src/onelogin/saml2/xmlparser.py
+++ b/src/onelogin/saml2/xmlparser.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Based on the lxml example from defusedxml
+# DTDForbidden, EntitiesForbidden, NotSupportedError are clones of the classes defined at defusedxml
 #
 # Copyright (c) 2013 by Christian Heimes <christian@python.org>
 # Licensed to PSF under a Contributor Agreement.
@@ -13,13 +14,49 @@ import threading
 
 from lxml import etree as _etree
 
-from defusedxml.lxml import DTDForbidden, EntitiesForbidden, NotSupportedError
-
 LXML3 = _etree.LXML_VERSION[0] >= 3
 
 __origin__ = "lxml.etree"
 
 tostring = _etree.tostring
+
+
+class DTDForbidden(ValueError):
+    """Document type definition is forbidden
+    """
+
+    def __init__(self, name, sysid, pubid):
+        super(DTDForbidden, self).__init__()
+        self.name = name
+        self.sysid = sysid
+        self.pubid = pubid
+
+    def __str__(self):
+        tpl = "DTDForbidden(name='{}', system_id={!r}, public_id={!r})"
+        return tpl.format(self.name, self.sysid, self.pubid)
+
+
+class EntitiesForbidden(ValueError):
+    """Entity definition is forbidden
+    """
+
+    def __init__(self, name, value, base, sysid, pubid, notation_name):
+        super(EntitiesForbidden, self).__init__()
+        self.name = name
+        self.value = value
+        self.base = base
+        self.sysid = sysid
+        self.pubid = pubid
+        self.notation_name = notation_name
+
+    def __str__(self):
+        tpl = "EntitiesForbidden(name='{}', system_id={!r}, public_id={!r})"
+        return tpl.format(self.name, self.sysid, self.pubid)
+
+
+class NotSupportedError(ValueError):
+    """The operation is not supported
+    """
 
 
 class RestrictedElement(_etree.ElementBase):


### PR DESCRIPTION
This removes the dependency on defusedxml by adopting the following classes into `xmlparser.py`:

- `DTDForbidden`
- `EntitiesForbidden`
- `NotSupportedError`

Resolves #233