### PR TITLE
Add artifact binding for ACS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'isodate>=0.5.0',
         'lxml>=3.3.5',
         'xmlsec>=1.0.5',
-        'defusedxml==0.6.0'
+        'defusedxml==0.6.0',
         'requests>=2.24.0'
     ],
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
@@ -52,6 +52,7 @@ setup(
             'pylint==1.9.4',
             'flake8==3.6.0',
             'coveralls==1.5.1',
+            'responses>=0.12.0'
         ),
     },
     keywords='saml saml2 xmlsec django flask pyramid python3',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'lxml>=3.3.5',
         'xmlsec>=1.0.5',
         'defusedxml==0.6.0'
+        'requests>=2.24.0'
     ],
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
     extras_require={

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -2,7 +2,6 @@ import logging
 import requests
 
 from base64 import b64decode
-from binascii import hexlify
 from hashlib import sha1
 
 from onelogin.saml2.utils import OneLogin_Saml2_Utils

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -77,8 +77,8 @@ class Artifact_Resolve_Request:
         return requests.post(
             url=idp['artifactResolutionService']['url'],
             cert=(
-                idp['artifactResolutionService']['clientKey'],
                 idp['artifactResolutionService']['clientCert'],
+                idp['artifactResolutionService']['clientKey'],
             ),
             data=self.get_soap_request(),
             headers=headers,

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -53,11 +53,11 @@ class Artifact_Resolve_Request:
         index, sha1_entity_id, message_handle = parse_saml2_artifact(saml_art)
 
         idp = self.__settings.get_idp_data()
-        if idp['assertionConsumerService']['index'] != index:
+        if idp['artifactResolutionService']['index'] != index:
             raise OneLogin_Saml2_ValidationError(
                 "The SourceID given in the SAML artifact ({}) does not correspond with a "
                 "configured ACS index ({})".format(
-                    index, idp['assertionConsumerService']['index']
+                    index, idp['artifactResolutionService']['index']
                 )
             )
 
@@ -75,10 +75,10 @@ class Artifact_Resolve_Request:
         idp = self.__settings.get_idp_data()
         headers = {"content-type": "application/soap+xml"}
         return requests.post(
-            url=idp['assertionConsumerService']['url'],
+            url=idp['artifactResolutionService']['url'],
             cert=(
-                idp['assertionConsumerService']['clientKey'],
-                idp['assertionConsumerService']['clientCert'],
+                idp['artifactResolutionService']['clientKey'],
+                idp['artifactResolutionService']['clientCert'],
             ),
             data=self.get_soap_request(),
             headers=headers,

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -1,0 +1,93 @@
+from base64 import b64decode
+from binascii import hexlify
+from hashlib import sha1
+
+import requests
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
+from onelogin.saml2.xml_templates import OneLogin_Saml2_Templates
+
+from .errors import OneLogin_Saml2_ValidationError
+
+
+def parse_saml2_artifact(artifact):
+    #
+    # SAMLBind - See 3.6.4 Artifact Format, for SAMLart format.
+    #
+    decoded = b64decode(artifact)
+    type_code = b'\x00\x04'
+
+    if decoded[:2] != type_code:
+        raise OneLogin_Saml2_ValidationError()
+
+    index = str(int.from_bytes(decoded[2:4], byteorder="big"))
+    sha1_entity_id = decoded[4:24]
+    message_handle = decoded[24:44]
+
+    return index, sha1_entity_id, message_handle
+
+
+class Artifact_Resolve_Request:
+    def __init__(self, settings, saml_art):
+        self.__settings = settings
+        self.validate_saml2_artifact(saml_art)
+        self.saml_art = saml_art
+
+        sp_data = self.__settings.get_sp_data()
+
+        uid = OneLogin_Saml2_Utils.generate_unique_id()
+        self.__id = uid
+
+        issue_instant = OneLogin_Saml2_Utils.parse_time_to_SAML(OneLogin_Saml2_Utils.now())
+
+        request = OneLogin_Saml2_Templates.ARTIFACT_RESOLVE_REQUEST % \
+            {
+                'id': uid,
+                'issue_instant': issue_instant,
+                'entity_id': sp_data['entityId'],
+                'artifact': saml_art
+            }
+
+        self.__artifact_resolve_request = request
+
+    def validate_saml2_artifact(self, saml_art):
+        index, sha1_entity_id, message_handle = parse_saml2_artifact(saml_art)
+
+        idp = self.__settings.get_idp_data()
+        if idp['assertionConsumerService']['index'] != index:
+            raise OneLogin_Saml2_ValidationError(
+                "The SourceID given in the SAML artifact ({}) does not correspond with a "
+                "configured ACS index ({})".format(
+                    index, idp['assertionConsumerService']['index']
+                )
+            )
+
+        if sha1_entity_id != sha1(idp['entityId'].encode('utf-8')).digest():
+            raise OneLogin_Saml2_ValidationError()
+
+    def get_soap_request(self):
+        request = OneLogin_Saml2_Templates.SOAP_ENVELOPE % \
+            {
+                'soap_body': self.__artifact_resolve_request
+            }
+        return request
+
+    def send(self):
+        idp = self.__settings.get_idp_data()
+        headers = {"content-type": "application/soap+xml"}
+        return requests.post(
+            url=idp['assertionConsumerService']['url'],
+            cert=(
+                idp['assertionConsumerService']['clientKey'],
+                idp['assertionConsumerService']['clientCert'],
+            ),
+            data=self.get_soap_request(),
+            headers=headers,
+        )
+
+    def get_id(self):
+        """
+        Returns the AuthNRequest ID.
+        :return: AuthNRequest ID
+        :rtype: string
+        """
+        return self.__id

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -85,6 +85,7 @@ class Artifact_Resolve_Request:
 
     def send(self):
         idp = self.__settings.get_idp_data()
+        security_data = self.__settings.get_security_data()
         headers = {"content-type": "application/soap+xml"}
         url = idp['artifactResolutionService']['url']
         data = self.get_soap_request()
@@ -93,12 +94,11 @@ class Artifact_Resolve_Request:
             "Doing a ArtifactResolve (POST) request to %s with data %s",
             url, data
         )
-
         return requests.post(
             url=url,
             cert=(
-                idp['artifactResolutionService']['clientCert'],
-                idp['artifactResolutionService']['clientKey'],
+                security_data['soapClientCert'],
+                security_data['soapClientKey'],
             ),
             data=data,
             headers=headers,

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -22,7 +22,10 @@ def parse_saml2_artifact(artifact):
     type_code = b'\x00\x04'
 
     if decoded[:2] != type_code:
-        raise OneLogin_Saml2_ValidationError()
+        raise OneLogin_Saml2_ValidationError(
+            "The received Artifact does not have the correct header.",
+            OneLogin_Saml2_ValidationError.WRONG_ARTIFACT_FORMAT
+        )
 
     index = str(int.from_bytes(decoded[2:4], byteorder="big"))
     sha1_entity_id = decoded[4:24]
@@ -107,8 +110,8 @@ class Artifact_Resolve_Request:
 
     def get_id(self):
         """
-        Returns the AuthNRequest ID.
-        :return: AuthNRequest ID
+        Returns the ArtifactResolve ID.
+        :return: ArtifactResolve ID
         :rtype: string
         """
         return self.__id

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -5,6 +5,7 @@ from hashlib import sha1
 import requests
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from onelogin.saml2.xml_templates import OneLogin_Saml2_Templates
+from onelogin.saml2.constants import OneLogin_Saml2_Constants
 
 from .errors import OneLogin_Saml2_ValidationError
 
@@ -69,7 +70,13 @@ class Artifact_Resolve_Request:
             {
                 'soap_body': self.__artifact_resolve_request
             }
-        return request
+
+        return OneLogin_Saml2_Utils.add_sign(
+            request,
+            self.__settings.get_sp_key(), self.__settings.get_sp_cert(),
+            sign_algorithm=OneLogin_Saml2_Constants.RSA_SHA256,
+            digest_algorithm=OneLogin_Saml2_Constants.SHA256,
+        )
 
     def send(self):
         idp = self.__settings.get_idp_data()

--- a/src/onelogin/saml2/artifact_resolve.py
+++ b/src/onelogin/saml2/artifact_resolve.py
@@ -1,13 +1,18 @@
+import logging
+import requests
+
 from base64 import b64decode
 from binascii import hexlify
 from hashlib import sha1
 
-import requests
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from onelogin.saml2.xml_templates import OneLogin_Saml2_Templates
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 
 from .errors import OneLogin_Saml2_ValidationError
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_saml2_artifact(artifact):
@@ -81,13 +86,21 @@ class Artifact_Resolve_Request:
     def send(self):
         idp = self.__settings.get_idp_data()
         headers = {"content-type": "application/soap+xml"}
+        url = idp['artifactResolutionService']['url']
+        data = self.get_soap_request()
+
+        logger.debug(
+            "Doing a ArtifactResolve (POST) request to %s with data %s",
+            url, data
+        )
+
         return requests.post(
-            url=idp['artifactResolutionService']['url'],
+            url=url,
             cert=(
                 idp['artifactResolutionService']['clientCert'],
                 idp['artifactResolutionService']['clientKey'],
             ),
-            data=self.get_soap_request(),
+            data=data,
             headers=headers,
         )
 

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -105,7 +105,7 @@ class Artifact_Response:
                 in_response_to = self.get_in_response_to()
                 if in_response_to and in_response_to != request_id:
                     raise OneLogin_Saml2_ValidationError(
-                        'The InResponseTo of the Logout Response: %s, does not match the ID of the Logout request sent by the SP: %s' % (in_response_to, request_id),
+                        'The InResponseTo of the Artifact Response: %s, does not match the ID of the Artifact Resolve Request sent by the SP: %s' % (in_response_to, request_id),
                         OneLogin_Saml2_ValidationError.WRONG_INRESPONSETO
                     )
 

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -91,7 +91,6 @@ class Artifact_Response:
                         },
                         OneLogin_Saml2_ValidationError.WRONG_ISSUER
                     )
-
             return True
         # pylint: disable=R0801
         except Exception as err:

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -23,7 +23,7 @@ class Artifact_Response:
 
     def get_issuer(self):
         """
-        Gets the Issuer of the Logout Response Message
+        Gets the Issuer of the Artifact Response
         :return: The Issuer
         :rtype: string
         """
@@ -114,8 +114,8 @@ class Artifact_Response:
 
     def get_in_response_to(self):
         """
-        Gets the ID of the LogoutRequest which this response is in response to
-        :returns: ID of LogoutRequest this LogoutResponse is in response to or None if it is not present
+        Gets the ID of the ArtifactResolve which this response is in response to
+        :returns: ID of ArtifactResolve this LogoutResponse is in response to or None if it is not present
         :rtype: str
         """
         return self.document.get('InResponseTo')
@@ -136,6 +136,10 @@ class Artifact_Response:
         return self.__artifact_response
 
     def get_response_xml(self):
+        """
+        The response is base64 encoded to make it possible to feed
+        it to the OneLogin_Saml2_Response class.
+        """
         return b64encode(
             tostring(
                 self.__query('//samlp:ArtifactResponse/samlp:Response')[0]

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -1,0 +1,144 @@
+from base64 import b64encode
+
+from onelogin.saml2.utils import (OneLogin_Saml2_Utils,
+                                  OneLogin_Saml2_ValidationError)
+from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
+
+
+class Artifact_Response:
+    def __init__(self, settings, response):
+        self.__settings = settings
+        self.__error = None
+        self.id = None
+
+        self.__artifact_response = response
+
+        soap_envelope = OneLogin_Saml2_XML.to_etree(self.__artifact_response)
+
+        self.document = OneLogin_Saml2_XML.query(
+            soap_envelope, '/soap:Envelope/soap:Body'
+        )[0].getchildren()[0]
+
+        self.id = self.document.get('ID', None)
+
+    def get_issuer(self):
+        """
+        Gets the Issuer of the Logout Response Message
+        :return: The Issuer
+        :rtype: string
+        """
+        issuer = None
+        issuer_nodes = self.__query('/samlp:ArtifactResponse/saml:Issuer')
+        if len(issuer_nodes) == 1:
+            issuer = OneLogin_Saml2_XML.element_text(issuer_nodes[0])
+        return issuer
+
+    def get_status(self):
+        """
+        Gets the Status
+        :return: The Status
+        :rtype: string
+        """
+        entries = self.__query('/samlp:ArtifactResponse/samlp:Status/samlp:StatusCode')
+        if len(entries) == 0:
+            return None
+        status = entries[0].attrib['Value']
+        return status
+
+    def is_valid(self, request_id, raise_exceptions=False):
+        """
+        Determines if the SAML ArtifactResponse is valid
+        :param request_id: The ID of the ArtifactResolve sent by this SP to the IdP
+        :type request_id: string
+
+        :param raise_exceptions: Whether to return false on failure or raise an exception
+        :type raise_exceptions: Boolean
+
+        :return: Returns if the SAML ArtifactResponse is or not valid
+        :rtype: boolean
+        """
+        self.__error = None
+        try:
+            idp_data = self.__settings.get_idp_data()
+            idp_entity_id = idp_data['entityId']
+
+            if self.__settings.is_strict():
+                res = OneLogin_Saml2_XML.validate_xml(self.document, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
+                if isinstance(res, str):
+                    raise OneLogin_Saml2_ValidationError(
+                        'Invalid SAML ArtifactResponse. Not match the saml-schema-protocol-2.0.xsd',
+                        OneLogin_Saml2_ValidationError.INVALID_XML_FORMAT
+                    )
+
+                security = self.__settings.get_security_data()
+
+                # Check if the InResponseTo of the Artifact Response matches the ID of the Artifact Resolve Request (requestId) if provided
+                in_response_to = self.get_in_response_to()
+                if in_response_to and in_response_to != request_id:
+                    raise OneLogin_Saml2_ValidationError(
+                        'The InResponseTo of the Logout Response: %s, does not match the ID of the Logout request sent by the SP: %s' % (in_response_to, request_id),
+                        OneLogin_Saml2_ValidationError.WRONG_INRESPONSETO
+                    )
+
+                # Check issuer
+                issuer = self.get_issuer()
+                if issuer is not None and issuer != idp_entity_id:
+                    raise OneLogin_Saml2_ValidationError(
+                        'Invalid issuer in the Logout Response (expected %(idpEntityId)s, got %(issuer)s)' %
+                        {
+                            'idpEntityId': idp_entity_id,
+                            'issuer': issuer
+                        },
+                        OneLogin_Saml2_ValidationError.WRONG_ISSUER
+                    )
+
+            return True
+        # pylint: disable=R0801
+        except Exception as err:
+            self.__error = str(err)
+            debug = self.__settings.is_debug_active()
+            if debug:
+                print(err)
+            if raise_exceptions:
+                raise
+            return False
+
+    def __query(self, query):
+        """
+        Extracts a node from the Etree (Logout Response Message)
+        :param query: Xpath Expression
+        :type query: string
+        :return: The queried node
+        :rtype: Element
+        """
+        return OneLogin_Saml2_XML.query(self.document, query)
+
+    def get_in_response_to(self):
+        """
+        Gets the ID of the LogoutRequest which this response is in response to
+        :returns: ID of LogoutRequest this LogoutResponse is in response to or None if it is not present
+        :rtype: str
+        """
+        return self.document.get('InResponseTo')
+
+    def get_error(self):
+        """
+        After executing a validation process, if it fails this method returns the cause
+        """
+        return self.__error
+
+    def get_xml(self):
+        """
+        Returns the XML that will be sent as part of the response
+        or that was received at the SP
+        :return: XML response body
+        :rtype: string
+        """
+        return self.__artifact_response
+
+    def get_response_xml(self):
+        return b64encode(
+            OneLogin_Saml2_XML.to_string(
+                self.__query('//samlp:ArtifactResponse/samlp:Response')[0]
+            )
+        )

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 from onelogin.saml2.utils import (OneLogin_Saml2_Utils,
                                   OneLogin_Saml2_ValidationError)
 from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
+from lxml import etree
 
 
 class Artifact_Response:
@@ -137,7 +138,7 @@ class Artifact_Response:
 
     def get_response_xml(self):
         return b64encode(
-            OneLogin_Saml2_XML.to_string(
+            etree.tostring(
                 self.__query('//samlp:ArtifactResponse/samlp:Response')[0]
             )
         )

--- a/src/onelogin/saml2/artifact_response.py
+++ b/src/onelogin/saml2/artifact_response.py
@@ -1,9 +1,8 @@
 from base64 import b64encode
-
+from defusedxml.lxml import tostring
 from onelogin.saml2.utils import (OneLogin_Saml2_Utils,
                                   OneLogin_Saml2_ValidationError)
 from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
-from lxml import etree
 
 
 class Artifact_Response:
@@ -138,7 +137,7 @@ class Artifact_Response:
 
     def get_response_xml(self):
         return b64encode(
-            etree.tostring(
+            tostring(
                 self.__query('//samlp:ArtifactResponse/samlp:Response')[0]
             )
         )

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -11,7 +11,9 @@ Initializes the SP SAML instance
 
 """
 
+import logging
 import xmlsec
+
 
 from onelogin.saml2 import compat
 from onelogin.saml2.authn_request import OneLogin_Saml2_Authn_Request
@@ -24,6 +26,9 @@ from onelogin.saml2.response import OneLogin_Saml2_Response
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.utils import OneLogin_Saml2_Utils, OneLogin_Saml2_Error, OneLogin_Saml2_ValidationError
 from onelogin.saml2.xmlparser import tostring
+
+
+logger = logging.getLogger(__name__)
 
 
 class OneLogin_Saml2_Auth(object):
@@ -102,6 +107,10 @@ class OneLogin_Saml2_Auth(object):
 
         TODO: should be integrated into the process_response method.
         """
+        logger.debug(
+            "Retrieved the SAMLArt %s via the ACS.", saml_art
+        )
+
         resolve_request = Artifact_Resolve_Request(self.__settings, saml_art)
         resolve_response = resolve_request.send()
         if resolve_response.status_code != 200:
@@ -110,6 +119,10 @@ class OneLogin_Saml2_Auth(object):
                     status_code=resolve_response.status_code, saml_art=saml_art
                 )
             )
+
+        logger.debug(
+            "Retrieved a ArtifactResponse with content %s", resolve_response.content
+        )
 
         artifact_response = Artifact_Response(self.__settings, resolve_response.content)
         if not artifact_response.is_valid(resolve_request.get_id()):

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -136,7 +136,7 @@ class OneLogin_Saml2_Auth(object):
         if not saml2_response.is_valid(self.__request_data, check_signatures=False):
             raise OneLogin_Saml2_ValidationError(
                 "The Response could not be validated due to the following error: {error}".format(
-                    error=artifact_response.get_error()
+                    error=saml2_response.get_error()
                 )
             )
 

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -133,7 +133,7 @@ class OneLogin_Saml2_Auth(object):
             )
 
         saml2_response = OneLogin_Saml2_Response(self.__settings, artifact_response.get_response_xml())
-        if not saml2_response.is_valid(self.__request_data, check_signatures=False):
+        if not saml2_response.is_valid(self.__request_data):
             raise OneLogin_Saml2_ValidationError(
                 "The Response could not be validated due to the following error: {error}".format(
                     error=saml2_response.get_error()

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -133,11 +133,13 @@ class OneLogin_Saml2_Auth(object):
             )
 
         saml2_response = OneLogin_Saml2_Response(self.__settings, artifact_response.get_response_xml())
-        if not saml2_response.is_valid(self.__request_data):
+        try:
+            saml2_response.is_valid(self.__request_data, raise_exceptions=True)
+        except OneLogin_Saml2_ValidationError as e:
             raise OneLogin_Saml2_ValidationError(
                 "The Response could not be validated due to the following error: {error}".format(
                     error=saml2_response.get_error()
-                )
+                ), code=e.code
             )
 
         return saml2_response

--- a/src/onelogin/saml2/constants.py
+++ b/src/onelogin/saml2/constants.py
@@ -56,6 +56,7 @@ class OneLogin_Saml2_Constants(object):
     NS_PREFIX_XSD = 'xsd'
     NS_PREFIX_XENC = 'xenc'
     NS_PREFIX_DS = 'ds'
+    NS_PREFIX_SOAP = 'soap'
 
     # Prefix:Namespace Mappings
     NSMAP = {
@@ -63,7 +64,8 @@ class OneLogin_Saml2_Constants(object):
         NS_PREFIX_SAML: NS_SAML,
         NS_PREFIX_DS: NS_DS,
         NS_PREFIX_XENC: NS_XENC,
-        NS_PREFIX_MD: NS_MD
+        NS_PREFIX_MD: NS_MD,
+        NS_PREFIX_SOAP: NS_SOAP
     }
 
     # Bindings

--- a/src/onelogin/saml2/constants.py
+++ b/src/onelogin/saml2/constants.py
@@ -96,6 +96,7 @@ class OneLogin_Saml2_Constants(object):
     STATUS_NO_PASSIVE = 'urn:oasis:names:tc:SAML:2.0:status:NoPassive'
     STATUS_PARTIAL_LOGOUT = 'urn:oasis:names:tc:SAML:2.0:status:PartialLogout'
     STATUS_PROXY_COUNT_EXCEEDED = 'urn:oasis:names:tc:SAML:2.0:status:ProxyCountExceeded'
+    STATUS_AUTHN_FAILED = 'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed'
 
     # Sign & Crypto
     SHA1 = 'http://www.w3.org/2000/09/xmldsig#sha1'

--- a/src/onelogin/saml2/errors.py
+++ b/src/onelogin/saml2/errors.py
@@ -119,7 +119,6 @@ class OneLogin_Saml2_ValidationError(Exception):
             * (int)   code.      The code error (defined in the error class).
         """
         assert isinstance(code, int)
-
         if errors is not None:
             message = message % errors
 

--- a/src/onelogin/saml2/errors.py
+++ b/src/onelogin/saml2/errors.py
@@ -110,6 +110,7 @@ class OneLogin_Saml2_ValidationError(Exception):
     WRONG_NUMBER_OF_SIGNATURES = 43
     RESPONSE_EXPIRED = 44
     AUTHN_CONTEXT_MISMATCH = 45
+    STATUS_CODE_AUTHNFAILED = 46
 
     def __init__(self, message, code=0, errors=None):
         """

--- a/src/onelogin/saml2/idp_metadata_parser.py
+++ b/src/onelogin/saml2/idp_metadata_parser.py
@@ -168,9 +168,7 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                     "./md:ArtifactResolutionService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:SOAP']"
                 )
 
-                if len(ars_nodes) > 0:
-                    idp_ars_url = ars_nodes[0].get('Location', None)
-                    idp_ars_index = ars_nodes[0].get('index', None)
+
 
                 signing_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'encryption'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
                 encryption_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'signing'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
@@ -201,11 +199,16 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                     data['idp']['singleLogoutService']['url'] = idp_slo_url
                     data['idp']['singleLogoutService']['binding'] = required_slo_binding
 
-                if idp_ars_url is not None:
-                    data['idp']['artifactResolutionService'] = {}
-                    data['idp']['artifactResolutionService']['url'] = idp_ars_url
-                    data['idp']['artifactResolutionService']['index'] = idp_ars_index
-                    data['idp']['artifactResolutionService']['binding'] = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                for ars_node in ars_nodes:
+                    idp_ars_url = ars_node.get('Location', None)
+                    idp_ars_index = ars_node.get('index', None)
+                    if idp_ars_url is not None:
+                        ars_list = data['idp'].setdefault('artifactResolutionService', [])
+                        ars_list.append({
+                            'url': idp_ars_url,
+                            'index': idp_ars_index,
+                            'binding': "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                        })
 
                 if want_authn_requests_signed is not None:
                     data['security'] = {}

--- a/src/onelogin/saml2/idp_metadata_parser.py
+++ b/src/onelogin/saml2/idp_metadata_parser.py
@@ -126,7 +126,7 @@ class OneLogin_Saml2_IdPMetadataParser(object):
         data = {}
 
         dom = OneLogin_Saml2_XML.to_etree(idp_metadata)
-        idp_entity_id = want_authn_requests_signed = idp_name_id_format = idp_sso_url = idp_slo_url = certs = None
+        idp_entity_id = want_authn_requests_signed = idp_name_id_format = idp_sso_url = idp_slo_url = idp_ars_url = idp_ars_index = certs = None
 
         entity_desc_path = '//md:EntityDescriptor'
         if entity_id:
@@ -163,6 +163,15 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                 if len(slo_nodes) > 0:
                     idp_slo_url = slo_nodes[0].get('Location', None)
 
+                ars_nodes = OneLogin_Saml2_XML.query(
+                    idp_descriptor_node,
+                    "./md:ArtifactResolutionService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:SOAP']"
+                )
+
+                if len(ars_nodes) > 0:
+                    idp_ars_url = ars_nodes[0].get('Location', None)
+                    idp_ars_index = ars_nodes[0].get('index', None)
+
                 signing_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'encryption'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
                 encryption_nodes = OneLogin_Saml2_XML.query(idp_descriptor_node, "./md:KeyDescriptor[not(contains(@use, 'signing'))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate")
 
@@ -191,6 +200,12 @@ class OneLogin_Saml2_IdPMetadataParser(object):
                     data['idp']['singleLogoutService'] = {}
                     data['idp']['singleLogoutService']['url'] = idp_slo_url
                     data['idp']['singleLogoutService']['binding'] = required_slo_binding
+
+                if idp_ars_url is not None:
+                    data['idp']['artifactResolutionService'] = {}
+                    data['idp']['artifactResolutionService']['url'] = idp_ars_url
+                    data['idp']['artifactResolutionService']['index'] = idp_ars_index
+                    data['idp']['artifactResolutionService']['binding'] = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
 
                 if want_authn_requests_signed is not None:
                     data['security'] = {}

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -334,17 +334,24 @@ class OneLogin_Saml2_Response(object):
         :raises: Exception. If the status is not success
         """
         status = OneLogin_Saml2_Utils.get_status(self.document)
-        code = status.get('code', None)
-        if code and code != OneLogin_Saml2_Constants.STATUS_SUCCESS:
-            splited_code = code.split(':')
+        codes = status.get('codes', None)
+        if codes and codes[0] != OneLogin_Saml2_Constants.STATUS_SUCCESS:
+            splited_code = codes[0].split(':')
             printable_code = splited_code.pop()
             status_exception_msg = 'The status code of the Response was not Success, was %s' % printable_code
             status_msg = status.get('msg', None)
             if status_msg:
                 status_exception_msg += ' -> ' + status_msg
+
+            exception_code = OneLogin_Saml2_ValidationError.STATUS_CODE_IS_NOT_SUCCESS
+
+            # See SAMLCore - 3.2.2.2. AuthnFailed is a second-level status code.
+            if len(codes) >= 2 and codes[1] == OneLogin_Saml2_Constants.STATUS_AUTHN_FAILED:
+                exception_code = OneLogin_Saml2_ValidationError.STATUS_CODE_AUTHNFAILED
+
             raise OneLogin_Saml2_ValidationError(
                 status_exception_msg,
-                OneLogin_Saml2_ValidationError.STATUS_CODE_IS_NOT_SUCCESS
+                exception_code
             )
 
     def check_one_condition(self):

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -48,7 +48,7 @@ class OneLogin_Saml2_Response(object):
             self.encrypted = True
             self.decrypted_document = self.__decrypt_assertion(decrypted_document)
 
-    def is_valid(self, request_data, request_id=None, check_signatures=True, raise_exceptions=False):
+    def is_valid(self, request_data, request_id=None, raise_exceptions=False):
         """
         Validates the response object.
 
@@ -287,36 +287,35 @@ class OneLogin_Saml2_Response(object):
                         OneLogin_Saml2_ValidationError.NO_SIGNED_MESSAGE
                     )
 
-            if check_signatures:
-                if not signed_elements or (not has_signed_response and not has_signed_assertion):
+            if not signed_elements or (not has_signed_response and not has_signed_assertion):
+                raise OneLogin_Saml2_ValidationError(
+                    'No Signature found. SAML Response rejected',
+                    OneLogin_Saml2_ValidationError.NO_SIGNATURE_FOUND
+                )
+            else:
+                cert = self.__settings.get_idp_cert()
+                fingerprint = idp_data.get('certFingerprint', None)
+                if fingerprint:
+                    fingerprint = OneLogin_Saml2_Utils.format_finger_print(fingerprint)
+                fingerprintalg = idp_data.get('certFingerprintAlgorithm', None)
+
+                multicerts = None
+                if 'x509certMulti' in idp_data and 'signing' in idp_data['x509certMulti'] and idp_data['x509certMulti']['signing']:
+                    multicerts = idp_data['x509certMulti']['signing']
+
+                # If find a Signature on the Response, validates it checking the original response
+                if has_signed_response and not OneLogin_Saml2_Utils.validate_sign(self.document, cert, fingerprint, fingerprintalg, xpath=OneLogin_Saml2_Utils.RESPONSE_SIGNATURE_XPATH, multicerts=multicerts, raise_exceptions=False):
                     raise OneLogin_Saml2_ValidationError(
-                        'No Signature found. SAML Response rejected',
-                        OneLogin_Saml2_ValidationError.NO_SIGNATURE_FOUND
+                        'Signature validation failed. SAML Response rejected',
+                        OneLogin_Saml2_ValidationError.INVALID_SIGNATURE
                     )
-                else:
-                    cert = self.__settings.get_idp_cert()
-                    fingerprint = idp_data.get('certFingerprint', None)
-                    if fingerprint:
-                        fingerprint = OneLogin_Saml2_Utils.format_finger_print(fingerprint)
-                    fingerprintalg = idp_data.get('certFingerprintAlgorithm', None)
 
-                    multicerts = None
-                    if 'x509certMulti' in idp_data and 'signing' in idp_data['x509certMulti'] and idp_data['x509certMulti']['signing']:
-                        multicerts = idp_data['x509certMulti']['signing']
-
-                    # If find a Signature on the Response, validates it checking the original response
-                    if has_signed_response and not OneLogin_Saml2_Utils.validate_sign(self.document, cert, fingerprint, fingerprintalg, xpath=OneLogin_Saml2_Utils.RESPONSE_SIGNATURE_XPATH, multicerts=multicerts, raise_exceptions=False):
-                        raise OneLogin_Saml2_ValidationError(
-                            'Signature validation failed. SAML Response rejected',
-                            OneLogin_Saml2_ValidationError.INVALID_SIGNATURE
-                        )
-
-                    document_check_assertion = self.decrypted_document if self.encrypted else self.document
-                    if has_signed_assertion and not OneLogin_Saml2_Utils.validate_sign(document_check_assertion, cert, fingerprint, fingerprintalg, xpath=OneLogin_Saml2_Utils.ASSERTION_SIGNATURE_XPATH, multicerts=multicerts, raise_exceptions=False):
-                        raise OneLogin_Saml2_ValidationError(
-                            'Signature validation failed. SAML Response rejected',
-                            OneLogin_Saml2_ValidationError.INVALID_SIGNATURE
-                        )
+                document_check_assertion = self.decrypted_document if self.encrypted else self.document
+                if has_signed_assertion and not OneLogin_Saml2_Utils.validate_sign(document_check_assertion, cert, fingerprint, fingerprintalg, xpath=OneLogin_Saml2_Utils.ASSERTION_SIGNATURE_XPATH, multicerts=multicerts, raise_exceptions=False):
+                    raise OneLogin_Saml2_ValidationError(
+                        'Signature validation failed. SAML Response rejected',
+                        OneLogin_Saml2_ValidationError.INVALID_SIGNATURE
+                    )
 
             return True
         except Exception as err:

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -666,8 +666,7 @@ class OneLogin_Saml2_Response(object):
         :returns: The signed elements tag names
         :rtype: list
         """
-        sign_nodes = self.__query('//ds:Signature')
-
+        sign_nodes = self.__query('//ds:Signature[not(ancestor::saml:Advice)]')
         signed_elements = []
         verified_seis = []
         verified_ids = []

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -640,7 +640,9 @@ class OneLogin_Saml2_Utils(object):
         :param dom: The Response as XML
         :type: Document
 
-        :returns: The Status, an array with the code and a message.
+        :returns: The Status, an array with the code and a message. 'code' entry is the
+                  topmost StatusCode, and 'codes' entry contains the StatusCodes in document
+                  order.
         :rtype: dict
         """
         status = {}
@@ -652,14 +654,14 @@ class OneLogin_Saml2_Utils(object):
                 OneLogin_Saml2_ValidationError.MISSING_STATUS
             )
 
-        code_entry = OneLogin_Saml2_XML.query(dom, '/samlp:Response/samlp:Status/samlp:StatusCode', status_entry[0])
-        if len(code_entry) != 1:
+        code_entries = OneLogin_Saml2_XML.query(dom, '/samlp:Response/samlp:Status//samlp:StatusCode', status_entry[0])
+        if not code_entries:
             raise OneLogin_Saml2_ValidationError(
                 'Missing Status Code on response',
                 OneLogin_Saml2_ValidationError.MISSING_STATUS_CODE
             )
-        code = code_entry[0].values()[0]
-        status['code'] = code
+        status['codes'] = [c.get('Value') for c in code_entries]
+        status['code'] = status['codes'][0]
 
         status['msg'] = ''
         message_entry = OneLogin_Saml2_XML.query(dom, '/samlp:Response/samlp:Status/samlp:StatusMessage', status_entry[0])

--- a/src/onelogin/saml2/xml_templates.py
+++ b/src/onelogin/saml2/xml_templates.py
@@ -33,6 +33,25 @@ class OneLogin_Saml2_Templates(object):
 %(requested_authn_context_str)s
 </samlp:AuthnRequest>"""
 
+    SOAP_ENVELOPE = """\
+<soap:Envelope
+ xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Body>
+%(soap_body)s
+</soap:Body>
+</soap:Envelope>
+    """
+
+    ARTIFACT_RESOLVE_REQUEST = """\
+<samlp:ArtifactResolve
+ xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+ xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+ ID="%(id)s" Version="2.0" IssueInstant="%(issue_instant)s">
+ <saml:Issuer>%(entity_id)s</saml:Issuer>
+ <samlp:Artifact>%(artifact)s</samlp:Artifact>
+</samlp:ArtifactResolve>
+    """
+
     LOGOUT_REQUEST = """\
 <samlp:LogoutRequest
   xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"

--- a/tests/data/artifact_response/artifact_response.xml
+++ b/tests/data/artifact_response/artifact_response.xml
@@ -1,0 +1,56 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="_1330416516" Version="2.0" IssueInstant="2020-04-09T08:31:46Z" InResponseTo="ONELOGIN_5ba93c9db0cff93f52b521d7420e43f6eda2784f">
+      <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+      <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+      </samlp:Status>
+      <samlp:Response InResponseTo="_7afa5ce49" Version="2.0" ID="_1072ee96" IssueInstant="2020-04-09T08:31:46Z">
+        <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+        <ds:Signature>
+          <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1072ee96">
+              <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                  <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xacml-saml"/>
+                </ds:Transform>
+              </ds:Transforms>
+              <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+              <ds:DigestValue/>
+            </ds:Reference>
+          </ds:SignedInfo>
+          <ds:SignatureValue/>
+          <ds:KeyInfo>
+            <ds:KeyName/>
+          </ds:KeyInfo>
+        </ds:Signature>
+        <samlp:Status>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        </samlp:Status>
+        <saml:Assertion Version="2.0" ID="_dc9f70e61c" IssueInstant="2020-04-09T08:31:46Z">
+          <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+          <saml:Subject>
+            <saml:NameID>s00000000:12345678</saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+              <saml:SubjectConfirmationData InResponseTo="_7afa5ce49" Recipient="https://sp.com/acs/" NotOnOrAfter="2020-04-10T08:31:46Z"/>
+            </saml:SubjectConfirmation>
+          </saml:Subject>
+          <saml:Conditions NotBefore="2012-12-20T18:48:27Z" NotOnOrAfter="2020-04-10T08:31:46Z">
+            <saml:AudienceRestriction>
+              <saml:Audience>sp.com</saml:Audience>
+            </saml:AudienceRestriction>
+          </saml:Conditions>
+          <saml:AuthnStatement SessionIndex="17" AuthnInstant="2020-04-09T08:31:46Z">
+            <saml:SubjectLocality Address="127.0.0.1"/>
+            <saml:AuthnContext>
+              <saml:AuthnContextClassRef> urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+          </saml:AuthnStatement>
+        </saml:Assertion>
+      </samlp:Response>
+    </samlp:ArtifactResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/tests/data/artifact_response/artifact_response_invalid.xml
+++ b/tests/data/artifact_response/artifact_response_invalid.xml
@@ -3,7 +3,7 @@
     <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="_1330416516" Version="2.0" IssueInstant="2020-04-09T08:31:46Z" InResponseTo="ONELOGIN_5ba93c9db0cff93f52b521d7420e43f6eda2784f">
       <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
       <samlp:Status>
-        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"/>
       </samlp:Status>
       <samlp:Response InResponseTo="_7afa5ce49" Version="2.0" ID="_1072ee96" IssueInstant="2020-04-09T08:31:46Z">
         <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
@@ -28,7 +28,7 @@
           </ds:KeyInfo>
         </ds:Signature>
         <samlp:Status>
-          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"/>
         </samlp:Status>
         <saml:Assertion Version="2.0" ID="_dc9f70e61c" IssueInstant="2020-04-09T08:31:46Z">
           <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>

--- a/tests/data/artifact_response/artifact_response_invalid.xml
+++ b/tests/data/artifact_response/artifact_response_invalid.xml
@@ -1,0 +1,56 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="_1330416516" Version="2.0" IssueInstant="2020-04-09T08:31:46Z" InResponseTo="ONELOGIN_5ba93c9db0cff93f52b521d7420e43f6eda2784f">
+      <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+      <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+      </samlp:Status>
+      <samlp:Response InResponseTo="_7afa5ce49" Version="2.0" ID="_1072ee96" IssueInstant="2020-04-09T08:31:46Z">
+        <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+        <ds:Signature>
+          <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1072ee96">
+              <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                  <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xacml-saml"/>
+                </ds:Transform>
+              </ds:Transforms>
+              <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+              <ds:DigestValue/>
+            </ds:Reference>
+          </ds:SignedInfo>
+          <ds:SignatureValue/>
+          <ds:KeyInfo>
+            <ds:KeyName/>
+          </ds:KeyInfo>
+        </ds:Signature>
+        <samlp:Status>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        </samlp:Status>
+        <saml:Assertion Version="2.0" ID="_dc9f70e61c" IssueInstant="2020-04-09T08:31:46Z">
+          <saml:Issuer>https://idp.com/saml/idp/metadata</saml:Issuer>
+          <saml:Subject>
+            <saml:NameID>s00000000:12345678</saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+              <saml:SubjectConfirmationData InResponseTo="_7afa5ce49" Recipient="https://sp.com/acs/" NotOnOrAfter="2020-04-10T08:31:46Z"/>
+            </saml:SubjectConfirmation>
+          </saml:Subject>
+          <saml:Conditions NotBefore="2012-12-20T18:48:27Z" NotOnOrAfter="2020-04-10T08:31:46Z">
+            <saml:AudienceRestriction>
+              <saml:Audience>sp.com</saml:Audience>
+            </saml:AudienceRestriction>
+          </saml:Conditions>
+          <saml:AuthnStatement SessionIndex="17" AuthnInstant="2020-04-09T08:31:46Z">
+            <saml:SubjectLocality Address="127.0.0.1"/>
+            <saml:AuthnContext>
+              <saml:AuthnContextClassRef> urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+          </saml:AuthnStatement>
+        </saml:Assertion>
+      </samlp:Response>
+    </samlp:ArtifactResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/tests/settings/settings11.json
+++ b/tests/settings/settings11.json
@@ -1,0 +1,33 @@
+{
+    "strict": false,
+    "debug": false,
+    "custom_base_path": "../../../tests/data/customPath/",
+    "sp": {
+        "entityId": "http://stuff.com/endpoints/metadata.php",
+        "assertionConsumerService": {
+            "url": "http://stuff.com/endpoints/endpoints/acs.php",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+    },
+    "idp": {
+        "entityId": "https://idp.com/saml/idp/metadata",
+        "singleSignOnService": {
+            "url": "https://idp.com/saml/idp/request_authentication",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        },
+        "artifactResolutionService": [{
+            "index": "0",
+            "url": "https://idp.com/saml/idp/resolve_artifact",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+        }],
+        "x509cert": "MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo"
+    },
+    "security": {
+        "soapClientCert": "abc",
+        "soapClientKey": "abc",
+        "authnRequestsSigned": false,
+        "wantAssertionsSigned": false,
+        "signMetadata": false
+    }
+}

--- a/tests/src/OneLogin/saml2_tests/artifact_response_test.py
+++ b/tests/src/OneLogin/saml2_tests/artifact_response_test.py
@@ -1,0 +1,104 @@
+from base64 import b64decode, b64encode
+from lxml import etree
+from datetime import datetime
+from datetime import timedelta
+from freezegun import freeze_time
+import json
+from os.path import dirname, join, exists
+import unittest
+from xml.dom.minidom import parseString
+
+from onelogin.saml2 import compat
+from onelogin.saml2.artifact_response import Artifact_Response
+from onelogin.saml2.settings import OneLogin_Saml2_Settings
+from onelogin.saml2.utils import OneLogin_Saml2_Utils, OneLogin_Saml2_ValidationError
+from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
+
+class Saml2_Artifact_Response_Test(unittest.TestCase):
+    data_path = join(dirname(dirname(dirname(dirname(__file__)))), 'data')
+    settings_path = join(dirname(dirname(dirname(dirname(__file__)))), 'settings')
+
+    def loadSettingsJSON(self, name='settings1.json'):
+        filename = join(self.settings_path, name)
+        if exists(filename):
+            stream = open(filename, 'r')
+            settings = json.load(stream)
+            stream.close()
+            return settings
+
+    def file_contents(self, filename):
+        f = open(filename, 'r')
+        content = f.read()
+        f.close()
+        return content
+
+    def testConstruct(self):
+        response = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response.xml'
+        ))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        response_enc = Artifact_Response(settings, response)
+
+        self.assertIsInstance(response_enc, Artifact_Response)
+
+    def testGetResponseXml(self):
+        response_data = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response.xml'
+        ))
+        response_etree = OneLogin_Saml2_XML.to_etree(response_data)
+        samlp_response = OneLogin_Saml2_XML.query(response_etree, '//samlp:Response')[0]
+        expected_data = b64encode(OneLogin_Saml2_XML.to_string(samlp_response))
+
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        response = Artifact_Response(settings, response_data)
+
+        self.assertEqual(
+            response.get_response_xml(),
+            expected_data
+        )
+
+    def testIsValid(self):
+        response = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response.xml'
+        ))
+        json_settings = self.loadSettingsJSON(name='settings11.json')
+        json_settings['strict'] = True
+        settings = OneLogin_Saml2_Settings(json_settings)
+        response = Artifact_Response(settings, response)
+
+        self.assertTrue(response.is_valid(
+            'ONELOGIN_5ba93c9db0cff93f52b521d7420e43f6eda2784f'
+        ))
+
+    def testGetIssuer(self):
+        response = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response.xml'
+        ))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        response = Artifact_Response(settings, response)
+
+        self.assertEqual(response.get_issuer(), 'https://idp.com/saml/idp/metadata')
+
+    def testGetStatus(self):
+        response = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response.xml'
+        ))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        response = Artifact_Response(settings, response)
+
+        self.assertEqual(response.get_status(), 'urn:oasis:names:tc:SAML:2.0:status:Success')
+
+    def testCheckStatus(self):
+        response = self.file_contents(join(
+            self.data_path, 'artifact_response', 'artifact_response_invalid.xml'
+        ))
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        response = Artifact_Response(settings, response)
+
+        with self.assertRaises(OneLogin_Saml2_ValidationError) as context:
+            response.check_status()
+
+        self.assertEqual(
+            str(context.exception),
+            'The status code of the ArtifactResponse was not Success, was Responder'
+        )

--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -81,6 +81,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
             "singleSignOnService": {
               "url": "https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            },
+            "artifactResolutionService": {
+                "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
+                "index": "2",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
             }
           }
         }
@@ -142,6 +147,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
             "singleSignOnService": {
               "url": "https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            },
+            "artifactResolutionService": {
+                "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
+                "index": "2",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
             }
           }
         }
@@ -180,6 +190,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
             "singleSignOnService": {
               "url": "https://idp.testshib.org/idp/profile/SAML2/POST/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            },
+            "artifactResolutionService": {
+                "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
+                "index": "2",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
             }
           }
         }

--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -82,11 +82,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
               "url": "https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
             },
-            "artifactResolutionService": {
+            "artifactResolutionService": [{
                 "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
                 "index": "2",
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
-            }
+            }]
           }
         }
         """
@@ -148,11 +148,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
               "url": "https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
             },
-            "artifactResolutionService": {
+            "artifactResolutionService": [{
                 "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
                 "index": "2",
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
-            }
+            }]
           }
         }
         """
@@ -191,11 +191,11 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
               "url": "https://idp.testshib.org/idp/profile/SAML2/POST/SSO",
               "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
             },
-            "artifactResolutionService": {
+            "artifactResolutionService": [{
                 "url": "https://idp.testshib.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution",
                 "index": "2",
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
-            }
+            }]
           }
         }
         """


### PR DESCRIPTION
We've used the wonderful python3-saml code to create an implementation for
two dutch government services (DigiD en eHerkenning). This meant that we had to make various changes
to python3-saml code. The biggest being the Artifact Binding for the ACS.

This PR adds support for the Artifact Binding for the ACS for python3-saml. I've tried as much as I could to keep
the coding style which was used in this project.