### PR TITLE
Use the xacml/saml2 XSD 

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -289,10 +289,10 @@ class OneLogin_Saml2_Logout_Request(object):
             get_data = ('get_data' in request_data and request_data['get_data']) or dict()
 
             if self.__settings.is_strict():
-                res = OneLogin_Saml2_XML.validate_xml(root, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
+                res = OneLogin_Saml2_XML.validate_xml(root, 'access_control-xacml-2.0-saml-assertion-schema-os.xsd', self.__settings.is_debug_active())
                 if isinstance(res, str):
                     raise OneLogin_Saml2_ValidationError(
-                        'Invalid SAML Logout Request. Not match the saml-schema-protocol-2.0.xsd',
+                        'Invalid SAML Logout Request. Not match the access_control-xacml-2.0-saml-assertion-schema-os.xsd',
                         OneLogin_Saml2_ValidationError.INVALID_XML_FORMAT
                     )
 

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -85,10 +85,10 @@ class OneLogin_Saml2_Logout_Response(object):
             get_data = request_data['get_data']
 
             if self.__settings.is_strict():
-                res = OneLogin_Saml2_XML.validate_xml(self.document, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
+                res = OneLogin_Saml2_XML.validate_xml(self.document, 'access_control-xacml-2.0-saml-assertion-schema-os.xsd', self.__settings.is_debug_active())
                 if isinstance(res, str):
                     raise OneLogin_Saml2_ValidationError(
-                        'Invalid SAML Logout Request. Not match the saml-schema-protocol-2.0.xsd',
+                        'Invalid SAML Logout Request. Not match the access_control-xacml-2.0-saml-assertion-schema-os.xsd',
                         OneLogin_Saml2_ValidationError.INVALID_XML_FORMAT
                     )
 

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -101,8 +101,8 @@ class OneLogin_Saml2_Response(object):
             has_signed_assertion = '{%s}Assertion' % OneLogin_Saml2_Constants.NS_SAML in signed_elements
 
             if self.__settings.is_strict():
-                no_valid_xml_msg = 'Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd'
-                res = OneLogin_Saml2_XML.validate_xml(self.document, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
+                no_valid_xml_msg = 'Invalid SAML Response. Not match the access_control-xacml-2.0-saml-assertion-schema-os.xsd'
+                res = OneLogin_Saml2_XML.validate_xml(self.document, 'access_control-xacml-2.0-saml-assertion-schema-os.xsd', self.__settings.is_debug_active())
                 if isinstance(res, str):
                     raise OneLogin_Saml2_ValidationError(
                         no_valid_xml_msg,
@@ -111,7 +111,7 @@ class OneLogin_Saml2_Response(object):
 
                 # If encrypted, check also the decrypted document
                 if self.encrypted:
-                    res = OneLogin_Saml2_XML.validate_xml(self.decrypted_document, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
+                    res = OneLogin_Saml2_XML.validate_xml(self.decrypted_document, 'access_control-xacml-2.0-saml-assertion-schema-os.xsd', self.__settings.is_debug_active())
                     if isinstance(res, str):
                         raise OneLogin_Saml2_ValidationError(
                             no_valid_xml_msg,

--- a/src/onelogin/saml2/schemas/access_control-xacml-2.0-context-schema-os.xsd
+++ b/src/onelogin/saml2/schemas/access_control-xacml-2.0-context-schema-os.xsd
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:oasis:names:tc:xacml:2.0:context:schema:os" xmlns:xacml="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xacml-context="urn:oasis:names:tc:xacml:2.0:context:schema:os" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="urn:oasis:names:tc:xacml:2.0:policy:schema:os" schemaLocation="access_control-xacml-2.0-policy-schema-os.xsd"/>
+	<!-- 	-->
+	<xs:element name="Request" type="xacml-context:RequestType"/>
+	<xs:complexType name="RequestType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Subject" maxOccurs="unbounded"/>
+			<xs:element ref="xacml-context:Resource" maxOccurs="unbounded"/>
+			<xs:element ref="xacml-context:Action"/>
+			<xs:element ref="xacml-context:Environment"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Response" type="xacml-context:ResponseType"/>
+	<xs:complexType name="ResponseType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Result" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Subject" type="xacml-context:SubjectType"/>
+	<xs:complexType name="SubjectType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="SubjectCategory" type="xs:anyURI" default="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Resource" type="xacml-context:ResourceType"/>
+	<xs:complexType name="ResourceType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:ResourceContent" minOccurs="0"/>
+			<xs:element ref="xacml-context:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="ResourceContent" type="xacml-context:ResourceContentType"/>
+	<xs:complexType name="ResourceContentType" mixed="true">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##any" processContents="lax"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Action" type="xacml-context:ActionType"/>
+	<xs:complexType name="ActionType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Environment" type="xacml-context:EnvironmentType"/>
+	<xs:complexType name="EnvironmentType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Attribute" type="xacml-context:AttributeType"/>
+	<xs:complexType name="AttributeType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:AttributeValue" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="AttributeValue" type="xacml-context:AttributeValueType"/>
+	<xs:complexType name="AttributeValueType" mixed="true">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##any" processContents="lax"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Result" type="xacml-context:ResultType"/>
+	<xs:complexType name="ResultType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:Decision"/>
+			<xs:element ref="xacml-context:Status" minOccurs="0"/>
+			<xs:element ref="xacml:Obligations" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="ResourceId" type="xs:string" use="optional"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Decision" type="xacml-context:DecisionType"/>
+	<xs:simpleType name="DecisionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Permit"/>
+			<xs:enumeration value="Deny"/>
+			<xs:enumeration value="Indeterminate"/>
+			<xs:enumeration value="NotApplicable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:element name="Status" type="xacml-context:StatusType"/>
+	<xs:complexType name="StatusType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:StatusCode"/>
+			<xs:element ref="xacml-context:StatusMessage" minOccurs="0"/>
+			<xs:element ref="xacml-context:StatusDetail" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="StatusCode" type="xacml-context:StatusCodeType"/>
+	<xs:complexType name="StatusCodeType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:StatusCode" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="Value" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="StatusMessage" type="xs:string"/>
+	<!-- -->
+	<xs:element name="StatusDetail" type="xacml-context:StatusDetailType"/>
+	<xs:complexType name="StatusDetailType">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="MissingAttributeDetail" type="xacml-context:MissingAttributeDetailType"/>
+	<xs:complexType name="MissingAttributeDetailType">
+		<xs:sequence>
+			<xs:element ref="xacml-context:AttributeValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+	</xs:complexType>
+	<!-- -->
+</xs:schema>

--- a/src/onelogin/saml2/schemas/access_control-xacml-2.0-policy-schema-os.xsd
+++ b/src/onelogin/saml2/schemas/access_control-xacml-2.0-policy-schema-os.xsd
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xacml="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:oasis:names:tc:xacml:2.0:policy:schema:os" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<!-- -->
+	<xs:element name="PolicySet" type="xacml:PolicySetType"/>
+	<xs:complexType name="PolicySetType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:PolicySetDefaults" minOccurs="0"/>
+			<xs:element ref="xacml:Target"/>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="xacml:PolicySet"/>
+				<xs:element ref="xacml:Policy"/>
+				<xs:element ref="xacml:PolicySetIdReference"/>
+				<xs:element ref="xacml:PolicyIdReference"/>
+				<xs:element ref="xacml:CombinerParameters"/>
+				<xs:element ref="xacml:PolicyCombinerParameters"/>
+				<xs:element ref="xacml:PolicySetCombinerParameters"/>
+			</xs:choice>
+			<xs:element ref="xacml:Obligations" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="PolicySetId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Version" type="xacml:VersionType" default="1.0"/>
+		<xs:attribute name="PolicyCombiningAlgId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="CombinerParameters" type="xacml:CombinerParametersType"/>
+	<xs:complexType name="CombinerParametersType">
+		<xs:sequence>
+			<xs:element ref="xacml:CombinerParameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="CombinerParameter" type="xacml:CombinerParameterType"/>
+	<xs:complexType name="CombinerParameterType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+		</xs:sequence>
+		<xs:attribute name="ParameterName" type="xs:string" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="RuleCombinerParameters" type="xacml:RuleCombinerParametersType"/>
+	<xs:complexType name="RuleCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="RuleIdRef" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="PolicyCombinerParameters" type="xacml:PolicyCombinerParametersType"/>
+	<xs:complexType name="PolicyCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="PolicyIdRef" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="PolicySetCombinerParameters" type="xacml:PolicySetCombinerParametersType"/>
+	<xs:complexType name="PolicySetCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="PolicySetIdRef" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="PolicySetIdReference" type="xacml:IdReferenceType"/>
+	<xs:element name="PolicyIdReference" type="xacml:IdReferenceType"/>
+	<!-- -->
+	<xs:element name="PolicySetDefaults" type="xacml:DefaultsType"/>
+	<xs:element name="PolicyDefaults" type="xacml:DefaultsType"/>
+	<xs:complexType name="DefaultsType">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element ref="xacml:XPathVersion"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="XPathVersion" type="xs:anyURI"/>
+	<!-- -->
+	<xs:complexType name="IdReferenceType">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="Version" type="xacml:VersionMatchType" use="optional"/>
+				<xs:attribute name="EarliestVersion" type="xacml:VersionMatchType" use="optional"/>
+				<xs:attribute name="LatestVersion" type="xacml:VersionMatchType" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:simpleType name="VersionType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="(\d+\.)*\d+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:simpleType name="VersionMatchType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="((\d+|\*)\.)*(\d+|\*|\+)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:element name="Policy" type="xacml:PolicyType"/>
+	<xs:complexType name="PolicyType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:PolicyDefaults" minOccurs="0"/>
+			<xs:element ref="xacml:CombinerParameters" minOccurs="0"/>
+			<xs:element ref="xacml:Target"/>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="xacml:CombinerParameters" minOccurs="0"/>
+				<xs:element ref="xacml:RuleCombinerParameters" minOccurs="0"/>
+				<xs:element ref="xacml:VariableDefinition"/>
+				<xs:element ref="xacml:Rule"/>
+			</xs:choice>
+			<xs:element ref="xacml:Obligations" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="PolicyId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Version" type="xacml:VersionType" default="1.0"/>
+		<xs:attribute name="RuleCombiningAlgId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Description" type="xs:string"/>
+	<!-- -->
+	<xs:element name="Rule" type="xacml:RuleType"/>
+	<xs:complexType name="RuleType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:Target" minOccurs="0"/>
+			<xs:element ref="xacml:Condition" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="RuleId" type="xs:string" use="required"/>
+		<xs:attribute name="Effect" type="xacml:EffectType" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:simpleType name="EffectType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Permit"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:element name="Target" type="xacml:TargetType"/>
+	<xs:complexType name="TargetType">
+		<xs:sequence>
+			<xs:element ref="xacml:Subjects" minOccurs="0"/>
+			<xs:element ref="xacml:Resources" minOccurs="0"/>
+			<xs:element ref="xacml:Actions" minOccurs="0"/>
+			<xs:element ref="xacml:Environments" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Subjects" type="xacml:SubjectsType"/>
+	<xs:complexType name="SubjectsType">
+		<xs:sequence>
+			<xs:element ref="xacml:Subject" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Subject" type="xacml:SubjectType"/>
+	<xs:complexType name="SubjectType">
+		<xs:sequence>
+			<xs:element ref="xacml:SubjectMatch" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Resources" type="xacml:ResourcesType"/>
+	<xs:complexType name="ResourcesType">
+		<xs:sequence>
+			<xs:element ref="xacml:Resource" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Resource" type="xacml:ResourceType"/>
+	<xs:complexType name="ResourceType">
+		<xs:sequence>
+			<xs:element ref="xacml:ResourceMatch" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Actions" type="xacml:ActionsType"/>
+	<xs:complexType name="ActionsType">
+		<xs:sequence>
+			<xs:element ref="xacml:Action" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Action" type="xacml:ActionType"/>
+	<xs:complexType name="ActionType">
+		<xs:sequence>
+			<xs:element ref="xacml:ActionMatch" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Environments" type="xacml:EnvironmentsType"/>
+	<xs:complexType name="EnvironmentsType">
+		<xs:sequence>
+			<xs:element ref="xacml:Environment" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Environment" type="xacml:EnvironmentType"/>
+	<xs:complexType name="EnvironmentType">
+		<xs:sequence>
+			<xs:element ref="xacml:EnvironmentMatch" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="SubjectMatch" type="xacml:SubjectMatchType"/>
+	<xs:complexType name="SubjectMatchType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+			<xs:choice>
+				<xs:element ref="xacml:SubjectAttributeDesignator"/>
+				<xs:element ref="xacml:AttributeSelector"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="MatchId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="ResourceMatch" type="xacml:ResourceMatchType"/>
+	<xs:complexType name="ResourceMatchType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+			<xs:choice>
+				<xs:element ref="xacml:ResourceAttributeDesignator"/>
+				<xs:element ref="xacml:AttributeSelector"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="MatchId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="ActionMatch" type="xacml:ActionMatchType"/>
+	<xs:complexType name="ActionMatchType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+			<xs:choice>
+				<xs:element ref="xacml:ActionAttributeDesignator"/>
+				<xs:element ref="xacml:AttributeSelector"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="MatchId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="EnvironmentMatch" type="xacml:EnvironmentMatchType"/>
+	<xs:complexType name="EnvironmentMatchType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+			<xs:choice>
+				<xs:element ref="xacml:EnvironmentAttributeDesignator"/>
+				<xs:element ref="xacml:AttributeSelector"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="MatchId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="VariableDefinition" type="xacml:VariableDefinitionType"/>
+	<xs:complexType name="VariableDefinitionType">
+		<xs:sequence>
+			<xs:element ref="xacml:Expression"/>
+		</xs:sequence>
+		<xs:attribute name="VariableId" type="xs:string" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Expression" type="xacml:ExpressionType" abstract="true"/>
+	<xs:complexType name="ExpressionType" abstract="true"/>
+	<!-- -->
+	<xs:element name="VariableReference" type="xacml:VariableReferenceType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="VariableReferenceType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="VariableId" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="AttributeSelector" type="xacml:AttributeSelectorType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="AttributeSelectorType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="RequestContextPath" type="xs:string" use="required"/>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:attribute name="MustBePresent" type="xs:boolean" use="optional" default="false"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="ResourceAttributeDesignator" type="xacml:AttributeDesignatorType" substitutionGroup="xacml:Expression"/>
+	<xs:element name="ActionAttributeDesignator" type="xacml:AttributeDesignatorType" substitutionGroup="xacml:Expression"/>
+	<xs:element name="EnvironmentAttributeDesignator" type="xacml:AttributeDesignatorType" substitutionGroup="xacml:Expression"/>
+	<!-- -->
+	<xs:complexType name="AttributeDesignatorType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+				<xs:attribute name="MustBePresent" type="xs:boolean" use="optional" default="false"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="SubjectAttributeDesignator" type="xacml:SubjectAttributeDesignatorType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="SubjectAttributeDesignatorType">
+		<xs:complexContent>
+			<xs:extension base="xacml:AttributeDesignatorType">
+				<xs:attribute name="SubjectCategory" type="xs:anyURI" use="optional" default="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="AttributeValue" type="xacml:AttributeValueType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="AttributeValueType" mixed="true">
+		<xs:complexContent mixed="true">
+			<xs:extension base="xacml:ExpressionType">
+				<xs:sequence>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:anyAttribute namespace="##any" processContents="lax"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Function" type="xacml:FunctionType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="FunctionType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="FunctionId" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Condition" type="xacml:ConditionType"/>
+	<xs:complexType name="ConditionType">
+		<xs:sequence>
+			<xs:element ref="xacml:Expression"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Apply" type="xacml:ApplyType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="ApplyType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:sequence>
+					<xs:element ref="xacml:Expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="FunctionId" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Obligations" type="xacml:ObligationsType"/>
+	<xs:complexType name="ObligationsType">
+		<xs:sequence>
+			<xs:element ref="xacml:Obligation" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="Obligation" type="xacml:ObligationType"/>
+	<xs:complexType name="ObligationType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeAssignment" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="ObligationId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="FulfillOn" type="xacml:EffectType" use="required"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="AttributeAssignment" type="xacml:AttributeAssignmentType"/>
+	<xs:complexType name="AttributeAssignmentType" mixed="true">
+		<xs:complexContent mixed="true">
+			<xs:extension base="xacml:AttributeValueType">
+				<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- -->
+</xs:schema>

--- a/src/onelogin/saml2/schemas/access_control-xacml-2.0-saml-assertion-schema-os.xsd
+++ b/src/onelogin/saml2/schemas/access_control-xacml-2.0-saml-assertion-schema-os.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+    targetNamespace="urn:oasis:xacml:2.0:saml:assertion:schema:os"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xacml-context="urn:oasis:names:tc:xacml:2.0:context:schema:os"
+    xmlns:xacml="urn:oasis:names:tc:xacml:2.0:policy:schema:os"
+    xmlns:xacml-saml="urn:oasis:xacml:2.0:saml:assertion:schema:os"
+    elementFormDefault="unqualified"
+    attributeFormDefault="unqualified"
+    blockDefault="substitution"
+    version="2.0">
+  <xs:import namespace="urn:oasis:names:tc:SAML:2.0:assertion"
+      schemaLocation="sstc-saml-schema-assertion-2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:SAML:2.0:protocol"
+      schemaLocation="sstc-saml-schema-protocol-2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xacml:2.0:context:schema:os"
+      schemaLocation="access_control-xacml-2.0-context-schema-os.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xacml:2.0:policy:schema:os"
+      schemaLocation="access_control-xacml-2.0-policy-schema-os.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+        Document identifier: access_control-xacml-2.0-saml-assertion-schema-cd-02.xsd
+        Location: http://docs.oasis-open.org/xacml/2.0/access_control-xacml-2.0-saml-assertion-schema-cd-os.xsd
+    </xs:documentation>
+  </xs:annotation>
+  <!--    -->
+  <xs:element name="XACMLAuthzDecisionStatement"
+           type="xacml-saml:XACMLAuthzDecisionStatementType"/>
+  <xs:complexType name="XACMLAuthzDecisionStatementType">
+    <xs:complexContent>
+      <xs:extension base="saml:StatementAbstractType">
+        <xs:sequence>
+          <xs:element ref="xacml-context:Response"/>
+          <xs:element ref="xacml-context:Request"  minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!--    -->
+  <xs:element name="XACMLPolicyStatement"
+           type="xacml-saml:XACMLPolicyStatementType"/>
+  <xs:complexType name="XACMLPolicyStatementType">
+    <xs:complexContent>
+      <xs:extension base="saml:StatementAbstractType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xacml:Policy"/>
+          <xs:element ref="xacml:PolicySet"/>
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</schema>

--- a/src/onelogin/saml2/schemas/access_control-xacml-2.0-saml-protocol-schema-os.xsd
+++ b/src/onelogin/saml2/schemas/access_control-xacml-2.0-saml-protocol-schema-os.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+    targetNamespace="urn:oasis:xacml:2.0:saml:protocol:schema:os"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:xacml-context="urn:oasis:names:tc:xacml:2.0:context:schema:os"
+    xmlns:xacml="urn:oasis:names:tc:xacml:2.0:policy:schema:os"
+    xmlns:xacml-samlp="urn:oasis:xacml:2.0:saml:protocol:schema:os"
+    elementFormDefault="unqualified"
+    attributeFormDefault="unqualified"
+    blockDefault="substitution"
+    version="2.0">
+  <xs:import namespace="urn:oasis:names:tc:SAML:2.0:assertion"
+      schemaLocation="sstc-saml-schema-assertion-2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:SAML:2.0:protocol"
+      schemaLocation="sstc-saml-schema-protocol-2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xacml:2.0:context:schema:os"
+      schemaLocation="access_control-xacml-2.0-context-schema-os.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xacml:2.0:policy:schema:os"
+      schemaLocation="access_control-xacml-2.0-policy-schema-os.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+        Document identifier: access_control-xacml-2.0-saml-protocol-schema-os.xsd
+        Location: http://docs.oasis-open.org/xacml/2.0/access_control-xacml-2.0-saml-protocol-schema-os.xsd
+    </xs:documentation>
+  </xs:annotation>
+  <!--    -->
+  <xs:element name="XACMLAuthzDecisionQuery"
+           type="xacml-samlp:XACMLAuthzDecisionQueryType"/>
+  <xs:complexType name="XACMLAuthzDecisionQueryType">
+    <xs:complexContent>
+      <xs:extension base="samlp:RequestAbstractType">
+        <xs:sequence>
+          <xs:element ref="xacml-context:Request"/>
+        </xs:sequence>
+        <xs:attribute name="InputContextOnly"
+                      type="boolean"
+                      use="optional"
+                      default="false"/>
+        <xs:attribute name="ReturnContext"
+                      type="boolean"
+                      use="optional"
+                      default="false"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!--    -->
+  <xs:element name="XACMLPolicyQuery"
+           type="xacml-samlp:XACMLPolicyQueryType"/>
+  <xs:complexType name="XACMLPolicyQueryType">
+    <xs:complexContent>
+      <xs:extension base="samlp:RequestAbstractType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xacml-context:Request"/>
+          <xs:element ref="xacml:Target"/>
+          <xs:element ref="xacml:PolicySetIdReference"/>
+          <xs:element ref="xacml:PolicyIdReference"/>
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</schema>

--- a/src/onelogin/saml2/schemas/sstc-saml-schema-assertion-2.0.xsd
+++ b/src/onelogin/saml2/schemas/sstc-saml-schema-assertion-2.0.xsd
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<schema
+    targetNamespace="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"
+    elementFormDefault="unqualified"
+    attributeFormDefault="unqualified"
+    blockDefault="substitution"
+    version="2.0">
+    <import namespace="http://www.w3.org/2000/09/xmldsig#"
+        schemaLocation="xmldsig-core-schema.xsd"/>
+    <import namespace="http://www.w3.org/2001/04/xmlenc#"
+        schemaLocation="xenc-schema.xsd"/>
+    <annotation>
+        <documentation>
+            Document identifier: sstc-saml-schema-assertion-2.0
+            Location: http://www.oasis-open.org/committees/documents.php?wg_abbrev=security
+            Revision history:
+            V1.0 (November, 2002):
+              Initial Standard Schema.
+            V1.1 (September, 2003):
+              Updates within the same V1.0 namespace.
+            V2.0 CD-04 (January, 2005):
+              New assertion schema for SAML V2.0 namespace.
+        </documentation>
+    </annotation>
+    <attributeGroup name="IDNameQualifiers">
+        <attribute name="NameQualifier" type="string" use="optional"/>
+        <attribute name="SPNameQualifier" type="string" use="optional"/>
+    </attributeGroup>
+    <element name="BaseID" type="saml:BaseIDAbstractType"/>
+    <complexType name="BaseIDAbstractType" abstract="true">
+        <attributeGroup ref="saml:IDNameQualifiers"/>
+    </complexType>
+    <element name="NameID" type="saml:NameIDType"/>
+    <complexType name="NameIDType">
+        <simpleContent>
+            <extension base="string">
+                <attributeGroup ref="saml:IDNameQualifiers"/>
+                <attribute name="Format" type="anyURI" use="optional"/>
+                <attribute name="SPProvidedID" type="string" use="optional"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <complexType name="EncryptedElementType">
+        <sequence>
+            <element ref="xenc:EncryptedData"/>
+            <element ref="xenc:EncryptedKey" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <element name="EncryptedID" type="saml:EncryptedElementType"/>
+    <element name="Issuer" type="saml:NameIDType"/>
+    <element name="AssertionIDRef" type="NCName"/>
+    <element name="AssertionURIRef" type="anyURI"/>
+    <element name="Assertion" type="saml:AssertionType"/>
+    <complexType name="AssertionType">
+        <sequence>
+            <element ref="saml:Issuer"/>
+            <element ref="ds:Signature" minOccurs="0"/>
+            <element ref="saml:Subject" minOccurs="0"/>
+            <element ref="saml:Conditions" minOccurs="0"/>
+            <element ref="saml:Advice" minOccurs="0"/>
+            <choice minOccurs="0" maxOccurs="unbounded">
+                <element ref="saml:Statement"/>
+                <element ref="saml:AuthnStatement"/>
+                <element ref="saml:AuthzDecisionStatement"/>
+                <element ref="saml:AttributeStatement"/>
+            </choice>
+        </sequence>
+        <attribute name="Version" type="string" use="required"/>
+        <attribute name="ID" type="ID" use="required"/>
+        <attribute name="IssueInstant" type="dateTime" use="required"/>
+    </complexType>
+    <element name="Subject" type="saml:SubjectType"/>
+    <complexType name="SubjectType">
+        <choice>
+            <sequence>
+                <choice>
+                    <element ref="saml:BaseID"/>
+                    <element ref="saml:NameID"/>
+                    <element ref="saml:EncryptedID"/>
+                </choice>
+                <element ref="saml:SubjectConfirmation" minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+            <element ref="saml:SubjectConfirmation" maxOccurs="unbounded"/>
+        </choice>
+    </complexType>
+    <element name="SubjectConfirmation" type="saml:SubjectConfirmationType"/>
+    <complexType name="SubjectConfirmationType">
+        <sequence>
+            <choice minOccurs="0">
+                <element ref="saml:BaseID"/>
+                <element ref="saml:NameID"/>
+                <element ref="saml:EncryptedID"/>
+            </choice>
+            <element ref="saml:SubjectConfirmationData" minOccurs="0"/>
+        </sequence>
+        <attribute name="Method" type="anyURI" use="required"/>
+    </complexType>
+    <element name="SubjectConfirmationData" type="saml:SubjectConfirmationDataType"/>
+    <complexType name="SubjectConfirmationDataType" mixed="true">
+        <complexContent>
+            <restriction base="anyType">
+                <sequence>
+                    <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+                <attribute name="NotBefore" type="dateTime" use="optional"/>
+                <attribute name="NotOnOrAfter" type="dateTime" use="optional"/>
+                <attribute name="Recipient" type="anyURI" use="optional"/>
+                <attribute name="InResponseTo" type="NCName" use="optional"/>
+                <attribute name="Address" type="string" use="optional"/>
+                <anyAttribute namespace="##other" processContents="lax"/>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <complexType name="KeyInfoConfirmationDataType" mixed="false">
+        <complexContent>
+            <restriction base="saml:SubjectConfirmationDataType">
+                <sequence>
+                    <element ref="ds:KeyInfo" maxOccurs="unbounded"/>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <element name="Conditions" type="saml:ConditionsType"/>
+    <complexType name="ConditionsType">
+        <choice minOccurs="0" maxOccurs="unbounded">
+            <element ref="saml:Condition"/>
+            <element ref="saml:AudienceRestriction"/>
+            <element ref="saml:OneTimeUse"/>
+            <element ref="saml:ProxyRestriction"/>
+        </choice>
+        <attribute name="NotBefore" type="dateTime" use="optional"/>
+        <attribute name="NotOnOrAfter" type="dateTime" use="optional"/>
+    </complexType>
+    <element name="Condition" type="saml:ConditionAbstractType"/>
+    <complexType name="ConditionAbstractType" abstract="true"/>
+    <element name="AudienceRestriction" type="saml:AudienceRestrictionType"/>
+    <complexType name="AudienceRestrictionType">
+        <complexContent>
+            <extension base="saml:ConditionAbstractType">
+                <sequence>
+                    <element ref="saml:Audience" maxOccurs="unbounded"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="Audience" type="anyURI"/>
+    <element name="OneTimeUse" type="saml:OneTimeUseType" />
+    <complexType name="OneTimeUseType">
+        <complexContent>
+            <extension base="saml:ConditionAbstractType"/>
+        </complexContent>
+    </complexType>
+    <element name="ProxyRestriction" type="saml:ProxyRestrictionType"/>
+    <complexType name="ProxyRestrictionType">
+    <complexContent>
+        <extension base="saml:ConditionAbstractType">
+            <sequence>
+                <element ref="saml:Audience" minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+            <attribute name="Count" type="nonNegativeInteger" use="optional"/>
+        </extension>
+	</complexContent>
+    </complexType>
+    <element name="Advice" type="saml:AdviceType"/>
+    <complexType name="AdviceType">
+        <choice minOccurs="0" maxOccurs="unbounded">
+            <element ref="saml:AssertionIDRef"/>
+            <element ref="saml:AssertionURIRef"/>
+            <element ref="saml:Assertion"/>
+            <element ref="saml:EncryptedAssertion"/>
+            <any namespace="##other" processContents="lax"/>
+        </choice>
+    </complexType>
+    <element name="EncryptedAssertion" type="saml:EncryptedElementType"/>
+    <element name="Statement" type="saml:StatementAbstractType"/>
+    <complexType name="StatementAbstractType" abstract="true"/>
+    <element name="AuthnStatement" type="saml:AuthnStatementType"/>
+    <complexType name="AuthnStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <sequence>
+                    <element ref="saml:SubjectLocality" minOccurs="0"/>
+                    <element ref="saml:AuthnContext"/>
+                </sequence>
+                <attribute name="AuthnInstant" type="dateTime" use="required"/>
+                <attribute name="SessionIndex" type="string" use="optional"/>
+                <attribute name="SessionNotOnOrAfter" type="dateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="SubjectLocality" type="saml:SubjectLocalityType"/>
+    <complexType name="SubjectLocalityType">
+        <attribute name="Address" type="string" use="optional"/>
+        <attribute name="DNSName" type="string" use="optional"/>
+    </complexType>
+    <element name="AuthnContext" type="saml:AuthnContextType"/>
+    <complexType name="AuthnContextType">
+        <sequence>
+            <choice>
+                <sequence>
+                    <element ref="saml:AuthnContextClassRef"/>
+                    <choice minOccurs="0">
+                        <element ref="saml:AuthnContextDecl"/>
+                        <element ref="saml:AuthnContextDeclRef"/>
+                    </choice>
+                </sequence>
+                <choice>
+                    <element ref="saml:AuthnContextDecl"/>
+                    <element ref="saml:AuthnContextDeclRef"/>
+                </choice>
+            </choice>
+            <element ref="saml:AuthenticatingAuthority" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <element name="AuthnContextClassRef" type="anyURI"/>
+    <element name="AuthnContextDeclRef" type="anyURI"/>
+    <element name="AuthnContextDecl" type="anyType"/>
+    <element name="AuthenticatingAuthority" type="anyURI"/>
+    <element name="AuthzDecisionStatement" type="saml:AuthzDecisionStatementType"/>
+    <complexType name="AuthzDecisionStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <sequence>
+                    <element ref="saml:Action" maxOccurs="unbounded"/>
+                    <element ref="saml:Evidence" minOccurs="0"/>
+                </sequence>
+                <attribute name="Resource" type="anyURI" use="required"/>
+                <attribute name="Decision" type="saml:DecisionType" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <simpleType name="DecisionType">
+        <restriction base="string">
+            <enumeration value="Permit"/>
+            <enumeration value="Deny"/>
+            <enumeration value="Indeterminate"/>
+        </restriction>
+    </simpleType>
+    <element name="Action" type="saml:ActionType"/>
+    <complexType name="ActionType">
+        <simpleContent>
+            <extension base="string">
+                <attribute name="Namespace" type="anyURI" use="required"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <element name="Evidence" type="saml:EvidenceType"/>
+    <complexType name="EvidenceType">
+        <choice maxOccurs="unbounded">
+            <element ref="saml:AssertionIDRef"/>
+            <element ref="saml:AssertionURIRef"/>
+            <element ref="saml:Assertion"/>
+            <element ref="saml:EncryptedAssertion"/>
+        </choice>
+    </complexType>
+    <element name="AttributeStatement" type="saml:AttributeStatementType"/>
+    <complexType name="AttributeStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <choice maxOccurs="unbounded">
+                    <element ref="saml:Attribute"/>
+                    <element ref="saml:EncryptedAttribute"/>
+                </choice>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="Attribute" type="saml:AttributeType"/>
+    <complexType name="AttributeType">
+        <sequence>
+            <element ref="saml:AttributeValue" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute name="Name" type="string" use="required"/>
+        <attribute name="NameFormat" type="anyURI" use="optional"/>
+        <attribute name="FriendlyName" type="string" use="optional"/>
+        <anyAttribute namespace="##other" processContents="lax"/>
+    </complexType>
+    <element name="AttributeValue" type="anyType" nillable="true"/>
+    <element name="EncryptedAttribute" type="saml:EncryptedElementType"/>
+</schema>

--- a/src/onelogin/saml2/schemas/sstc-saml-schema-protocol-2.0.xsd
+++ b/src/onelogin/saml2/schemas/sstc-saml-schema-protocol-2.0.xsd
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+    targetNamespace="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    elementFormDefault="unqualified"
+    attributeFormDefault="unqualified"
+    blockDefault="substitution"
+    version="2.0">
+    <import namespace="urn:oasis:names:tc:SAML:2.0:assertion"
+        schemaLocation="sstc-saml-schema-assertion-2.0.xsd"/>
+    <import namespace="http://www.w3.org/2000/09/xmldsig#"
+        schemaLocation="http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd"/>
+    <annotation>
+        <documentation>
+            Document identifier: draft-sstc-saml-schema-protocol-2.0
+            Location: http://www.oasis-open.org/committees/documents.php?wg_abbrev=security
+            Revision history:
+            V1.0 (November, 2002):
+              Initial Standard Schema.
+            V1.1 (September, 2003):
+              Updates within the same V1.0 namespace.
+            V2.0 CD-04 (January, 2005):
+              New protocol schema based in a SAML V2.0 namespace.
+     </documentation>
+    </annotation>
+    <complexType name="RequestAbstractType" abstract="true">
+        <sequence>
+            <element ref="saml:Issuer" minOccurs="0"/>
+            <element ref="ds:Signature" minOccurs="0"/>
+            <element ref="samlp:Extensions" minOccurs="0"/>
+        </sequence>
+        <attribute name="ID" type="ID" use="required"/>
+        <attribute name="Version" type="string" use="required"/>
+        <attribute name="IssueInstant" type="dateTime" use="required"/>
+        <attribute name="Destination" type="anyURI" use="optional"/>
+    	<attribute name="Consent" type="anyURI" use="optional"/>
+    </complexType>
+    <element name="Extensions" type="samlp:ExtensionsType"/>
+    <complexType name="ExtensionsType">
+        <sequence>
+            <any namespace="##other" processContents="lax" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <complexType name="StatusResponseType">
+    	<sequence>
+            <element ref="saml:Issuer" minOccurs="0"/>
+            <element ref="ds:Signature" minOccurs="0"/>
+            <element ref="samlp:Extensions" minOccurs="0"/>
+            <element ref="samlp:Status"/>
+    	</sequence>
+    	<attribute name="ID" type="ID" use="required"/>
+    	<attribute name="InResponseTo" type="NCName" use="optional"/>
+    	<attribute name="Version" type="string" use="required"/>
+    	<attribute name="IssueInstant" type="dateTime" use="required"/>
+    	<attribute name="Destination" type="anyURI" use="optional"/>
+    	<attribute name="Consent" type="anyURI" use="optional"/>
+    </complexType>
+    <element name="Status" type="samlp:StatusType"/>
+    <complexType name="StatusType">
+        <sequence>
+            <element ref="samlp:StatusCode"/>
+            <element ref="samlp:StatusMessage" minOccurs="0"/>
+            <element ref="samlp:StatusDetail" minOccurs="0"/>
+        </sequence>
+    </complexType>
+    <element name="StatusCode" type="samlp:StatusCodeType"/>
+    <complexType name="StatusCodeType">
+        <sequence>
+            <element ref="samlp:StatusCode" minOccurs="0"/>
+        </sequence>
+        <attribute name="Value" type="anyURI" use="required"/>
+    </complexType>
+    <element name="StatusMessage" type="string"/>
+    <element name="StatusDetail" type="samlp:StatusDetailType"/>
+    <complexType name="StatusDetailType">
+        <sequence>
+            <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <element name="AssertionIDRequest" type="samlp:AssertionIDRequestType"/>
+    <complexType name="AssertionIDRequestType">
+    	<complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <element ref="saml:AssertionIDRef" maxOccurs="unbounded"/>
+                </sequence>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="SubjectQuery" type="samlp:SubjectQueryAbstractType"/>
+    <complexType name="SubjectQueryAbstractType" abstract="true">
+    	<complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <element ref="saml:Subject"/>
+                </sequence>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="AuthnQuery" type="samlp:AuthnQueryType"/>
+    <complexType name="AuthnQueryType">
+        <complexContent>
+            <extension base="samlp:SubjectQueryAbstractType">
+                <sequence>
+                    <element ref="samlp:RequestedAuthnContext" minOccurs="0"/>
+                </sequence>
+                <attribute name="SessionIndex" type="string" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="RequestedAuthnContext" type="samlp:RequestedAuthnContextType"/>
+    <complexType name="RequestedAuthnContextType">
+        <choice>
+            <element ref="saml:AuthnContextClassRef" maxOccurs="unbounded"/>
+            <element ref="saml:AuthnContextDeclRef" maxOccurs="unbounded"/>
+        </choice>
+        <attribute name="Comparison" type="samlp:AuthnContextComparisonType" use="optional"/>
+    </complexType>
+    <simpleType name="AuthnContextComparisonType">
+        <restriction base="string">
+            <enumeration value="exact"/>
+            <enumeration value="minimum"/>
+            <enumeration value="maximum"/>
+            <enumeration value="better"/>
+        </restriction>
+    </simpleType>
+    <element name="AttributeQuery" type="samlp:AttributeQueryType"/>
+    <complexType name="AttributeQueryType">
+        <complexContent>
+            <extension base="samlp:SubjectQueryAbstractType">
+                <sequence>
+                    <element ref="saml:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="AuthzDecisionQuery" type="samlp:AuthzDecisionQueryType"/>
+    <complexType name="AuthzDecisionQueryType">
+        <complexContent>
+            <extension base="samlp:SubjectQueryAbstractType">
+                <sequence>
+                    <element ref="saml:Action" maxOccurs="unbounded"/>
+                    <element ref="saml:Evidence" minOccurs="0"/>
+                </sequence>
+                <attribute name="Resource" type="anyURI" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="AuthnRequest" type="samlp:AuthnRequestType"/>
+    <complexType name="AuthnRequestType">
+        <complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <element ref="saml:Subject" minOccurs="0"/>
+                    <element ref="samlp:NameIDPolicy" minOccurs="0"/>
+                    <element ref="saml:Conditions" minOccurs="0"/>
+                    <element ref="samlp:RequestedAuthnContext" minOccurs="0"/>
+                    <element ref="samlp:Scoping" minOccurs="0"/>
+                </sequence>
+                <attribute name="ForceAuthn" type="boolean" use="optional"/>
+                <attribute name="IsPassive" type="boolean" use="optional"/>
+                <attribute name="ProtocolBinding" type="anyURI" use="optional"/>
+                <attribute name="AssertionConsumerServiceIndex" type="unsignedShort" use="optional"/>
+                <attribute name="AssertionConsumerServiceURL" type="anyURI" use="optional"/>
+                <attribute name="AttributeConsumingServiceIndex" type="unsignedShort" use="optional"/>
+                <attribute name="ProviderName" type="string" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="NameIDPolicy" type="samlp:NameIDPolicyType"/>
+    <complexType name="NameIDPolicyType">
+        <attribute name="Format" type="anyURI" use="optional"/>
+        <attribute name="SPNameQualifier" type="string" use="optional"/>
+        <attribute name="AllowCreate" type="boolean" use="optional"/>
+    </complexType>
+    <element name="Scoping" type="samlp:ScopingType"/>
+    <complexType name="ScopingType">
+        <sequence>
+            <element ref="samlp:IDPList" minOccurs="0"/>
+            <element ref="samlp:RequesterID" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute name="ProxyCount" type="nonNegativeInteger" use="optional"/>
+    </complexType>
+    <element name="RequesterID" type="anyURI"/>
+    <element name="IDPList" type="samlp:IDPListType"/>
+    <complexType name="IDPListType">
+        <sequence>
+            <element ref="samlp:IDPEntry" maxOccurs="unbounded"/>
+            <element ref="samlp:GetComplete" minOccurs="0"/>
+        </sequence>
+    </complexType>
+    <element name="IDPEntry" type="samlp:IDPEntryType"/>
+    <complexType name="IDPEntryType">
+        <attribute name="ProviderID" type="anyURI" use="required"/>
+        <attribute name="Name" type="string" use="optional"/>
+        <attribute name="Loc" type="anyURI" use="optional"/>
+    </complexType>
+    <element name="GetComplete" type="anyURI"/>
+    <element name="Response" type="samlp:ResponseType"/>
+    <complexType name="ResponseType">
+    	<complexContent>
+            <extension base="samlp:StatusResponseType">
+                <choice minOccurs="0" maxOccurs="unbounded">
+                    <element ref="saml:Assertion"/>
+                    <element ref="saml:EncryptedAssertion"/>
+                </choice>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="ArtifactResolve" type="samlp:ArtifactResolveType"/>
+    <complexType name="ArtifactResolveType">
+    	<complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <element ref="samlp:Artifact"/>
+                </sequence>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="Artifact" type="string"/>
+    <element name="ArtifactResponse" type="samlp:ArtifactResponseType"/>
+    <complexType name="ArtifactResponseType">
+    	<complexContent>
+            <extension base="samlp:StatusResponseType">
+                <sequence>
+                    <any namespace="##any" processContents="lax" minOccurs="0"/>
+                </sequence>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="ManageNameIDRequest" type="samlp:ManageNameIDRequestType"/>
+    <complexType name="ManageNameIDRequestType">
+    	<complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <choice>
+                        <element ref="saml:NameID"/>
+                        <element ref="saml:EncryptedID"/>
+                    </choice>
+                    <choice>
+                        <element ref="samlp:NewID"/>
+                        <element ref="samlp:NewEncryptedID"/>
+                        <element ref="samlp:Terminate"/>
+                    </choice>
+                </sequence>
+            </extension>
+    	</complexContent>
+    </complexType>
+    <element name="NewID" type="string"/>
+    <element name="NewEncryptedID" type="saml:EncryptedElementType"/>
+    <element name="Terminate" type="samlp:TerminateType"/>
+    <complexType name="TerminateType"/>
+    <element name="ManageNameIDResponse" type="samlp:StatusResponseType"/>
+    <element name="LogoutRequest" type="samlp:LogoutRequestType"/>
+    <complexType name="LogoutRequestType">
+        <complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <choice>
+                        <element ref="saml:BaseID"/>
+                        <element ref="saml:NameID"/>
+                        <element ref="saml:EncryptedID"/>
+                    </choice>
+                    <element ref="samlp:SessionIndex" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+                <attribute name="Reason" type="string" use="optional"/>
+                <attribute name="NotOnOrAfter" type="dateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="SessionIndex" type="string"/>
+    <element name="LogoutResponse" type="samlp:StatusResponseType"/>
+    <element name="NameIDMappingRequest" type="samlp:NameIDMappingRequestType"/>
+    <complexType name="NameIDMappingRequestType">
+        <complexContent>
+            <extension base="samlp:RequestAbstractType">
+                <sequence>
+                    <choice>
+                        <element ref="saml:BaseID"/>
+                        <element ref="saml:NameID"/>
+                        <element ref="saml:EncryptedID"/>
+                    </choice>
+                    <element ref="samlp:NameIDPolicy"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="NameIDMappingResponse" type="samlp:NameIDMappingResponseType"/>
+    <complexType name="NameIDMappingResponseType">
+        <complexContent>
+            <extension base="samlp:StatusResponseType">
+                <choice>
+                    <element ref="saml:NameID"/>
+                    <element ref="saml:EncryptedID"/>
+                </choice>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -831,7 +831,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Response(settings, message)
         self.assertFalse(response_2.is_valid(request_data))
-        self.assertEqual('Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd', response_2.get_error())
+        self.assertEqual('Invalid SAML Response. Not match the access_control-xacml-2.0-saml-assertion-schema-os.xsd', response_2.get_error())
 
     def testValidateNumAssertions(self):
         """


### PR DESCRIPTION
The SAML service we use (eHerkenning) uses the xacml/saml profile (http://docs.oasis-open.org/xacml/xacml-saml-profile/v2.0/xacml-saml-profile-v2.0.html). In our implementation I replaced the XSDs with the saml/xacml ones, like I did below. However, I can understand if the preference would be to implement this otherwise. By making it configurable for example.

I can make a PR that would make the XSDs configurable, if that is something that would be preferred. I figured I discuss it before putting any effort into it.