### PR TITLE
Ignore the Advice section when looking for signatures.

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -666,8 +666,7 @@ class OneLogin_Saml2_Response(object):
         :returns: The signed elements tag names
         :rtype: list
         """
-        sign_nodes = self.__query('//ds:Signature')
-
+        sign_nodes = self.__query('//ds:Signature[not(ancestor::saml:Advice)]')
         signed_elements = []
         verified_seis = []
         verified_ids = []


### PR DESCRIPTION
There can be legal Signature blocks in the 'Advice' element of a response. Since python3-saml does not suport doing
anything with the advice section, skipping it altogether seems. like the best solution.

This is part of #237 as well. 