### PR TITLE
Add an option to use query string for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,9 +562,10 @@ req = {
 
     # Advanced request options
     "https": "",
-    "lowercase_urlencoding": "",
     "request_uri": "",
-    "query_string": ""
+    "query_string": "",
+    "validate_signature_from_qs": False,
+    "lowercase_urlencoding": False
 }
 ```
 
@@ -596,11 +597,11 @@ An explanation of some advanced request parameters:
 
 * `https` - Defaults to ``off``. Set this to ``on`` if you receive responses over HTTPS.
 
-* `lowercase_urlencoding` - Defaults to `false`. ADFS users should set this to `true`.
-
-* `request_uri` - The path where your SAML server recieves requests. Set this if requests are not recieved at the server's root.
+* `request_uri` - The path where your SAML server receives requests. Set this if requests are not received at the server's root.
 
 * `query_string` - Set this with additional query parameters that should be passed to the request endpoint.
+
+* `validate_signature_from_qs` - If `True`, use `query_string` to validate request and response signatures. Otherwise, use `get_data`. Defaults to `False`. Note that when using `get_data`, query parameters need to be url-encoded for validation. By default we use upper-case url-encoding. Some IdPs, notably Microsoft AD, use lower-case url-encoding, which makes signature validation to fail. To fix this issue, either pass `query_string` and set `validate_signature_from_qs` to `True`, which works for all IdPs, or set `lowercase_urlencoding` to `True`, which only works for AD.
 
 
 #### Initiate SSO ####


### PR DESCRIPTION
When validating request or response signature in process_slo() we
currently rebuild query string from 'get_data' elements. This requires
URL encoding components of the string. Unfortunately, some IdPs (Azure
AD, ADFS) use lower-case encoding. To handle this, one needs to pass
lowercase_urlencoding=True. This complicates code that needs to support
different IdPs.

Instead, if 'query_string' is passed, take parts from it directly. This
avoids the need to URL encode them. This is similar to the
`retrieveParametersFromServer` argument in the PHP version.