### PR TITLE
make the redirect scheme matcher case-insensitive.

### DIFF
--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -210,7 +210,7 @@ class OneLogin_Saml2_Utils(object):
             url = '%s%s' % (OneLogin_Saml2_Utils.get_self_url_host(request_data), url)
 
         # Verify that the URL is to a http or https site.
-        if re.search('^https?://', url) is None:
+        if re.search('^https?://', url, flags=re.IGNORECASE) is None:
             raise OneLogin_Saml2_Error(
                 'Redirect to invalid URL: ' + url,
                 OneLogin_Saml2_Error.REDIRECT_INVALID_URL


### PR DESCRIPTION
We're having an issue where a customer's SSO_URL is set to HTTPS://... and triggers a failure. We're fixing this on our end and I wanted to send the patch upstream as well.