### PR TITLE
Deprecate server_port from request data dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,6 @@ This parameter has the following scheme:
 req = {
     "http_host": "",
     "script_name": "",
-    "server_port": "",
     "get_data": "",
     "post_data": "",
 
@@ -594,7 +593,6 @@ def prepare_from_django_request(request):
     return {
         'http_host': request.META['HTTP_HOST'],
         'script_name': request.META['PATH_INFO'],
-        'server_port': request.META['SERVER_PORT'],
         'get_data': request.GET.copy(),
         'post_data': request.POST.copy()
     }
@@ -602,8 +600,7 @@ def prepare_from_django_request(request):
 def prepare_from_flask_request(request):
     url_data = urlparse(request.url)
     return {
-        'http_host': request.host,
-        'server_port': url_data.port,
+        'http_host': request.netloc,
         'script_name': request.path,
         'get_data': request.args.copy(),
         'post_data': request.form.copy()

--- a/demo-django/demo/views.py
+++ b/demo-django/demo/views.py
@@ -20,7 +20,6 @@ def prepare_django_request(request):
         'https': 'on' if request.is_secure() else 'off',
         'http_host': request.META['HTTP_HOST'],
         'script_name': request.META['PATH_INFO'],
-        'server_port': request.META['SERVER_PORT'],
         'get_data': request.GET.copy(),
         # Uncomment if using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144
         # 'lowercase_urlencoding': True,

--- a/demo-flask/index.py
+++ b/demo-flask/index.py
@@ -21,11 +21,9 @@ def init_saml_auth(req):
 
 def prepare_flask_request(request):
     # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
-    url_data = urlparse(request.url)
     return {
         'https': 'on' if request.scheme == 'https' else 'off',
-        'http_host': request.host,
-        'server_port': url_data.port,
+        'http_host': request.netloc,
         'script_name': request.path,
         'get_data': request.args.copy(),
         # Uncomment if using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144

--- a/demo-tornado/views.py
+++ b/demo-tornado/views.py
@@ -157,9 +157,8 @@ def prepare_tornado_request(request):
 
     result = {
         'https': 'on' if request == 'https' else 'off',
-        'http_host': tornado.httputil.split_host_and_port(request.host)[0],
+        'http_host': request.host,
         'script_name': request.path,
-        'server_port': tornado.httputil.split_host_and_port(request.host)[1],
         'get_data': dataDict,
         'post_data': dataDict,
         'query_string': request.query

--- a/demo_pyramid/demo_pyramid/views.py
+++ b/demo_pyramid/demo_pyramid/views.py
@@ -15,19 +15,16 @@ def init_saml_auth(req):
 
 
 def prepare_pyramid_request(request):
-    # Uncomment this portion to set the request.scheme and request.server_port
+    # Uncomment this portion to set the request.scheme
     # based on the supplied `X-Forwarded` headers.
     # Useful for running behind reverse proxies or balancers.
     #
     # if 'X-Forwarded-Proto' in request.headers:
     #    request.scheme = request.headers['X-Forwarded-Proto']
-    # if 'X-Forwarded-Port' in request.headers:
-    #    request.server_port = int(request.headers['X-Forwarded-Port'])
 
     return {
         'https': 'on' if request.scheme == 'https' else 'off',
         'http_host': request.host,
-        'server_port': request.server_port,
         'script_name': request.path,
         'get_data': request.GET.copy(),
         # Uncomment if using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -4,6 +4,7 @@
 # MIT License
 
 from base64 import b64decode
+
 from lxml import etree
 from datetime import datetime
 from datetime import timedelta
@@ -1528,22 +1529,31 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         self.assertFalse(response_5.is_valid(request_data))
         self.assertEqual('The NameID of the Response is not encrypted and the SP require it', response_5.get_error())
 
+    def testIsInValidEncIssues_2(self):
         settings_info_2 = self.loadSettingsJSON('settings3.json')
         settings_info_2['strict'] = True
         settings_info_2['security']['wantNameIdEncrypted'] = True
         settings_2 = OneLogin_Saml2_Settings(settings_info_2)
 
         request_data = {
-            'http_host': 'pytoolkit.com',
-            'server_port': 8000,
             'script_name': '',
             'request_uri': '?acs',
         }
+        for separate_port in (False, True):
+            if separate_port:
+                request_data.update({
+                    'http_host': 'pytoolkit.com',
+                    'server_port': 8000,
+                })
+            else:
+                request_data.update({
+                    'http_host': 'pytoolkit.com:8000',
+                })
 
-        message_2 = self.file_contents(join(self.data_path, 'responses', 'valid_encrypted_assertion_encrypted_nameid.xml.base64'))
-        response_6 = OneLogin_Saml2_Response(settings_2, message_2)
-        self.assertFalse(response_6.is_valid(request_data))
-        self.assertEqual('The attributes have expired, based on the SessionNotOnOrAfter of the AttributeStatement of this Response', response_6.get_error())
+            message_2 = self.file_contents(join(self.data_path, 'responses', 'valid_encrypted_assertion_encrypted_nameid.xml.base64'))
+            response_6 = OneLogin_Saml2_Response(settings_2, message_2)
+            self.assertFalse(response_6.is_valid(request_data))
+            self.assertEqual('The attributes have expired, based on the SessionNotOnOrAfter of the AttributeStatement of this Response', response_6.get_error())
 
     def testIsInValidCert(self):
         """

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -190,7 +190,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         request_data = {
             'http_host': 'example.com:443'
         }
-        self.assertEqual('example.com', OneLogin_Saml2_Utils.get_self_host(request_data))
+        self.assertEqual('example.com:443', OneLogin_Saml2_Utils.get_self_host(request_data))
 
         request_data = {
             'http_host': 'example.com:ok'
@@ -210,11 +210,6 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
             'https': 'on'
         }
         self.assertTrue(OneLogin_Saml2_Utils.is_https(request_data))
-
-        request_data = {
-            'server_port': '80'
-        }
-        self.assertFalse(OneLogin_Saml2_Utils.is_https(request_data))
 
         request_data = {
             'server_port': '443'


### PR DESCRIPTION
`server_port` is unnecessary, since the HTTP Host header sent by the client already includes any non-standard port. (This is stuffed into `http_host`.)

In addition, when the Python application server is sitting behind a reverse proxy/TLS terminator, SERVER_PORT is likely to be wrong anyway (since it would be the server port of the non-reverse-proxied server).

See https://github.com/onelogin/python3-saml/issues/273#issuecomment-885566427