### PR TITLE
Implement get_last_assertion_issue_instant()

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ Main class of OneLogin Python Toolkit
 * ***get_last_message_id*** The ID of the last Response SAML message processed.
 * ***get_last_assertion_id*** The ID of the last assertion processed.
 * ***get_last_assertion_not_on_or_after*** The ``NotOnOrAfter`` value of the valid ``SubjectConfirmationData`` node (if any) of the last assertion processed (is only calculated with strict = true)
+* ***get_last_assertion_issue_instant*** The `IssueInstant` value of the last assertion processed.
 
 #### OneLogin_Saml2_Auth - authn_request.py ####
 

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -71,6 +71,7 @@ class OneLogin_Saml2_Auth(object):
         self._last_request_id = None
         self._last_message_id = None
         self._last_assertion_id = None
+        self._last_assertion_issue_instant = None
         self._last_authn_contexts = []
         self._last_request = None
         self._last_response = None
@@ -105,6 +106,7 @@ class OneLogin_Saml2_Auth(object):
         self._session_expiration = response.get_session_not_on_or_after()
         self._last_message_id = response.get_id()
         self._last_assertion_id = response.get_assertion_id()
+        self._last_assertion_issue_instant = response.get_assertion_issue_instant()
         self._last_authn_contexts = response.get_authn_contexts()
         self._authenticated = True
         self._last_assertion_not_on_or_after = response.get_assertion_not_on_or_after()
@@ -372,6 +374,13 @@ class OneLogin_Saml2_Auth(object):
         :rtype: string
         """
         return self._last_assertion_id
+
+    def get_last_assertion_issue_instant(self):
+        """
+        :returns: The IssueInstant of the last assertion processed.
+        :rtype: unix/posix timestamp|None
+        """
+        return self._last_assertion_issue_instant
 
     def get_last_authn_contexts(self):
         """

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -917,3 +917,16 @@ class OneLogin_Saml2_Response(object):
                 OneLogin_Saml2_ValidationError.WRONG_NUMBER_OF_ASSERTIONS
             )
         return self._query_assertion('')[0].get('ID', None)
+
+    def get_assertion_issue_instant(self):
+        """
+        :returns: the IssueInstant of the assertion in the response
+        :rtype: unix/posix timestamp|None
+        """
+        if not self.validate_num_assertions():
+            raise OneLogin_Saml2_ValidationError(
+                'SAML Response must contain 1 assertion',
+                OneLogin_Saml2_ValidationError.WRONG_NUMBER_OF_ASSERTIONS
+            )
+        issue_instant = self._query_assertion('')[0].get('IssueInstant', None)
+        return OneLogin_Saml2_Utils.parse_SAML_to_time(issue_instant)

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -1433,7 +1433,7 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertIsNone(auth.get_last_assertion_not_on_or_after())
         self.assertEqual(auth.get_last_assertion_issue_instant(), 1392773821)
 
-        # NotOnOrAfter is only calculated with strict = true 
+        # NotOnOrAfter is only calculated with strict = true
         # If invalid, response id and assertion id are not obtained
 
         settings['strict'] = True

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -1415,7 +1415,7 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
 
     def testGetInfoFromLastResponseReceived(self):
         """
-        Tests the get_last_message_id, get_last_assertion_id and get_last_assertion_not_on_or_after
+        Tests the get_last_message_id, get_last_assertion_id, get_last_assertion_not_on_or_after and get_last_assertion_issue_instant
         of the OneLogin_Saml2_Auth class
         """
         settings = self.loadSettingsJSON()
@@ -1431,8 +1431,9 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertEqual(auth.get_last_message_id(), 'pfx42be40bf-39c3-77f0-c6ae-8bf2e23a1a2e')
         self.assertEqual(auth.get_last_assertion_id(), 'pfx57dfda60-b211-4cda-0f63-6d5deb69e5bb')
         self.assertIsNone(auth.get_last_assertion_not_on_or_after())
+        self.assertEqual(auth.get_last_assertion_issue_instant(), 1392773821)
 
-        # NotOnOrAfter is only calculated with strict = true
+        # NotOnOrAfter is only calculated with strict = true 
         # If invalid, response id and assertion id are not obtained
 
         settings['strict'] = True
@@ -1442,6 +1443,7 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertIsNone(auth.get_last_message_id())
         self.assertIsNone(auth.get_last_assertion_id())
         self.assertIsNone(auth.get_last_assertion_not_on_or_after())
+        self.assertIsNone(auth.get_last_assertion_issue_instant())
 
         request_data['https'] = 'on'
         request_data['http_host'] = 'pitbulk.no-ip.org'
@@ -1452,6 +1454,7 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertEqual(auth.get_last_message_id(), 'pfx42be40bf-39c3-77f0-c6ae-8bf2e23a1a2e')
         self.assertEqual(auth.get_last_assertion_id(), 'pfx57dfda60-b211-4cda-0f63-6d5deb69e5bb')
         self.assertEqual(auth.get_last_assertion_not_on_or_after(), 2671081021)
+        self.assertEqual(auth.get_last_assertion_issue_instant(), 1392773821)
 
     def testGetIdFromLogoutRequest(self):
         """


### PR DESCRIPTION
Currently the way of retrieving `IssueInstant` time from the last assertion processed `SAMLResponse` is possible by (please correct me if there's an easier way):
1) Retrieving the XML string by calling `auth.get_last_response_xml()`
2) Parsing the XML document from the XML string using `xml_utils.to_etree()`
3) Querying the last Assertion using `xml_utils.query()`
4) Parsing the SAML2 timestamp using `parse_SAML_to_time()`

Implementing `get_last_assertion_issue_instant()` replaces the four calls above with one.

Why retrieve `IssueInstant`?
There is an odd case where an IdP can send no `notOnOrAfter` within `Conditions` or `SubjectConfirmationData` in an Assertion, as these parameters are both [optional](http://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd). `IssueInstant` on the other hand is a required parameter that provides an additional tool for applications to implement additional security measurements by limiting the amount of time they'll process an Assertion past `IssueInstant`