### PR TITLE
Don't require yanked version of lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'lxml==4.7.0',
+        'lxml~=4.7.1',
         'isodate>=0.6.1',
         'xmlsec>=1.3.9'
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'lxml~=4.7.1',
+        'lxml>4.7.1',
         'isodate>=0.6.1',
         'xmlsec>=1.3.9'
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'lxml>4.7.1',
+        'lxml<4.7.1',
         'isodate>=0.6.1',
         'xmlsec>=1.3.9'
     ],


### PR DESCRIPTION
Version 4.7.0 of lxml was yanked from pypi because it was missing some required data.

Version 4.7.1 replaces it; changing the specifier from `==` to `~=` allows any 4.7.x series lxml.

**EDIT:** I just saw #292 / a55cc9a379da03eff9f96a886f6164fd0792a62e ... has this been reported upstream to lxml?