### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -51,7 +52,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,13 @@
 
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,8 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7,3.5,3.6,3.7, 3.8,3.9]
-
+        python-version:
+          - "2.7"
+          - "3.5"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
+        pip install -U setuptools
         sudo apt-get update -qq
         sudo apt-get install -qq swig python-dev libxml2-dev libxmlsec1-dev
         make install-req
@@ -59,6 +60,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
+        pip install -U setuptools
         sudo apt-get update -qq
         sudo apt-get install -qq swig python-dev libxml2-dev libxmlsec1-dev
         make install-req

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ TESTS=tests/src/OneLogin/saml2_tests
 SOURCES=$(MAIN_SOURCE) $(DEMOS) $(TESTS)
 
 install-req:
-	$(PIP) install --upgrade 'setuptools<45.0.0'
 	$(PIP) install .
 
 install-test:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     author='OneLogin',
     author_email='support@onelogin.com',


### PR DESCRIPTION
This PR:

* fixes the CI pipeline for less duplicate builds
* fixes the quoting in the python-version list (a bare `3.10` would be parsed as `3.1` since it looks like a float)
* removes the forcible downgrading of setuptools in favor of upgrading it at the start of CI builds
* adds Python 3.10 to the CI build matrix
* adds Python 3.10 to the trove specifiers for PyPI

Fixes #294