### PR TITLE
Allow process_response and process_slo to raise is_valid exceptions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ keywords = [
     "identity",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -32,11 +31,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "lxml>=4.6.5,!=4.7.0",
-    "xmlsec>=1.3.9",
+    "lxml>=6.0.0",
+    "xmlsec>=1.3.14",
     "isodate>=0.6.1",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://saml.info"

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -111,12 +111,15 @@ class OneLogin_Saml2_Auth(object):
         self._last_response_in_response_to = response.get_in_response_to()
         self._last_assertion_not_on_or_after = response.get_assertion_not_on_or_after()
 
-    def process_response(self, request_id=None):
+    def process_response(self, request_id=None, raise_exceptions=False):
         """
         Process the SAML Response sent by the IdP.
 
         :param request_id: Is an optional argument. Is the ID of the AuthNRequest sent by this SP to the IdP.
         :type request_id: string
+
+        :param raise_exceptions: Whether to return raise an exception during is_valid check
+        :type raise_exceptions: Boolean
 
         :raises: OneLogin_Saml2_Error.SAML_RESPONSE_NOT_FOUND, when a POST with a SAMLResponse is not found
         """
@@ -128,7 +131,7 @@ class OneLogin_Saml2_Auth(object):
             response = self.response_class(self._settings, self._request_data["post_data"]["SAMLResponse"])
             self._last_response = response.get_xml_document()
 
-            if response.is_valid(self._request_data, request_id):
+            if response.is_valid(self._request_data, request_id, raise_exceptions=raise_exceptions):
                 self.store_valid_response(response)
             else:
                 self._errors.append("invalid_response")
@@ -138,7 +141,7 @@ class OneLogin_Saml2_Auth(object):
             self._errors.append("invalid_binding")
             raise OneLogin_Saml2_Error("SAML Response not found, Only supported HTTP_POST Binding", OneLogin_Saml2_Error.SAML_RESPONSE_NOT_FOUND)
 
-    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None):
+    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None, raise_exceptions=False):
         """
         Process the SAML Logout Response / Logout Request sent by the IdP.
 
@@ -147,6 +150,9 @@ class OneLogin_Saml2_Auth(object):
 
         :param request_id: The ID of the LogoutRequest sent by this SP to the IdP
         :type request_id: string
+
+        :param raise_exceptions: Whether to return raise an exception during is_valid check
+        :type raise_exceptions: Boolean
 
         :returns: Redirection url
         """
@@ -160,7 +166,7 @@ class OneLogin_Saml2_Auth(object):
             if not self.validate_response_signature(get_data):
                 self._errors.append("invalid_logout_response_signature")
                 self._errors.append("Signature validation failed. Logout Response rejected")
-            elif not logout_response.is_valid(self._request_data, request_id):
+            elif not logout_response.is_valid(self._request_data, request_id, raise_exceptions=raise_exceptions):
                 self._errors.append("invalid_logout_response")
             elif logout_response.get_status() != OneLogin_Saml2_Constants.STATUS_SUCCESS:
                 self._errors.append("logout_not_success")
@@ -175,7 +181,7 @@ class OneLogin_Saml2_Auth(object):
             if not self.validate_request_signature(get_data):
                 self._errors.append("invalid_logout_request_signature")
                 self._errors.append("Signature validation failed. Logout Request rejected")
-            elif not logout_request.is_valid(self._request_data):
+            elif not logout_request.is_valid(self._request_data, raise_exceptions=raise_exceptions):
                 self._errors.append("invalid_logout_request")
             else:
                 if not keep_local_session:


### PR DESCRIPTION
It is nice to be able to see the actual is_valid exception so you know exactly what line it was raised on in the validation code. This is helpful in determining exactly what rule was broken and if it is possible to disable that check.

Currently the raise_exceptions is a useful feature that isn't really accessible to the caller unless they make their own response object.

This feature was requested in the old project before it was retired.  https://github.com/SAML-Toolkits/python-saml/pull/253