### PR TITLE
Replace deprecated `datetime.utcfromtimestamp`, `datetime.utcnow`

### DIFF
--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -10,8 +10,7 @@ Auxiliary class of SAML Python Toolkit.
 import base64
 import warnings
 from copy import deepcopy
-import calendar
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha1, sha256, sha384, sha512
 from isodate import parse_duration as duration_parser
 import re
@@ -389,7 +388,7 @@ class OneLogin_Saml2_Utils(object):
         :return: SAML2 timestamp.
         :rtype: string
         """
-        data = datetime.utcfromtimestamp(float(time))
+        data = datetime.fromtimestamp(float(time), timezone.utc)
         return data.strftime(OneLogin_Saml2_Utils.TIME_FORMAT)
 
     @staticmethod
@@ -405,17 +404,17 @@ class OneLogin_Saml2_Utils(object):
         :rtype: int
         """
         try:
-            data = datetime.strptime(timestr, OneLogin_Saml2_Utils.TIME_FORMAT)
+            data = datetime.strptime(timestr, OneLogin_Saml2_Utils.TIME_FORMAT).replace(tzinfo=timezone.utc)
         except ValueError:
             try:
-                data = datetime.strptime(timestr, OneLogin_Saml2_Utils.TIME_FORMAT_2)
+                data = datetime.strptime(timestr, OneLogin_Saml2_Utils.TIME_FORMAT_2).replace(tzinfo=timezone.utc)
             except ValueError:
                 elem = OneLogin_Saml2_Utils.TIME_FORMAT_WITH_FRAGMENT.match(timestr)
                 if not elem:
                     raise Exception("time data %s does not match format %s" % (timestr, r"yyyy-mm-ddThh:mm:ss(\.s+)?Z"))
-                data = datetime.strptime(elem.groups()[0] + "Z", OneLogin_Saml2_Utils.TIME_FORMAT)
+                data = datetime.strptime(elem.groups()[0] + "Z", OneLogin_Saml2_Utils.TIME_FORMAT).replace(tzinfo=timezone.utc)
 
-        return calendar.timegm(data.utctimetuple())
+        return int(data.timestamp())
 
     @staticmethod
     def now():
@@ -423,7 +422,7 @@ class OneLogin_Saml2_Utils(object):
         :return: unix timestamp of actual time.
         :rtype: int
         """
-        return calendar.timegm(datetime.utcnow().utctimetuple())
+        return int(datetime.now(timezone.utc).timestamp())
 
     @staticmethod
     def parse_duration(duration, timestamp=None):
@@ -445,10 +444,10 @@ class OneLogin_Saml2_Utils(object):
 
         timedelta = duration_parser(duration)
         if timestamp is None:
-            data = datetime.utcnow() + timedelta
+            data = datetime.now(timezone.utc) + timedelta
         else:
-            data = datetime.utcfromtimestamp(timestamp) + timedelta
-        return calendar.timegm(data.utctimetuple())
+            data = datetime.fromtimestamp(timestamp, timezone.utc) + timedelta
+        return int(data.timestamp())
 
     @staticmethod
     def get_expire_time(cache_duration=None, valid_until=None):

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -4,7 +4,7 @@
 import json
 from os.path import dirname, join, exists
 from time import strftime
-from datetime import datetime
+from datetime import datetime, timezone
 import unittest
 
 from onelogin.saml2 import compat
@@ -97,7 +97,7 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
         self.assertNotIn("cacheDuration", metadata5)
         self.assertIn('validUntil="2014-10-01T11:04:29Z"', metadata5)
 
-        datetime_value = datetime.now()
+        datetime_value = datetime.now(timezone.utc)
         metadata6 = OneLogin_Saml2_Metadata.builder(sp_data, security["authnRequestsSigned"], security["wantAssertionsSigned"], datetime_value, "P1Y", contacts, organization)
         self.assertIsNotNone(metadata5)
         self.assertIn("<md:SPSSODescriptor", metadata6)


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.12.html#deprecated

> [`datetime.datetime`](https://docs.python.org/3/library/datetime.html#datetime.datetime)’s [`utcnow()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and [`utcfromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [`now()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) and [`fromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) with the `tz` parameter set to [`datetime.UTC`](https://docs.python.org/3/library/datetime.html#datetime.UTC).