### PR TITLE
Disable coveralls job if the needed secrets aren’t available

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,6 +70,7 @@ jobs:
         make flake8
         make black
   coveralls:
+    if: ${{ github.secret_source == 'Actions' }}
     runs-on: ubuntu-22.04
     environment: CI
     steps:


### PR DESCRIPTION
For security, GitHub Actions does not make secrets available to pull requests from external contributors, so the coveralls job was always failing for those PRs. Disable this job when secrets are not available.