### PR TITLE
Added Root path to flask request config. This fixes issues with flask applications running not as the root for a domain.

### DIFF
--- a/demo-flask/index.py
+++ b/demo-flask/index.py
@@ -21,7 +21,7 @@ def prepare_flask_request(request):
     return {
         "https": "on" if request.scheme == "https" else "off",
         "http_host": request.host,
-        "script_name": request.path,
+        "script_name": request.root_path + request.path,
         "get_data": request.args.copy(),
         # Uncomment if using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144
         # 'lowercase_urlencoding': True,


### PR DESCRIPTION
Currently in the flask application the  `prepare_flask_request` function only uses the `request.path`. However, for application that do not run at their domain route, this produces incorrect URLs. The solution is to show `request.root_path + request.path`. If there is no root, then the result is the same.